### PR TITLE
feat: markdown-ready Mermaid copy + iframe embed for shared workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,12 @@ If a component doesn't exist, build it in `/components/ui/` using Radix primitiv
 - Auth protects `/dashboard/*` and `/api/workflows/*` only
 - Guest drafts persist to localStorage, migrate to cloud on sign-in
 - Providers: GitHub OAuth + Google OAuth via Auth.js v5
+
+### Sharing & Embeds
+
+- Public share view: `/w/[shareId]` — full chrome (header, export drawer, simulator)
+- Iframe embed: `/embed/[shareId]` — minimal chrome, fit-to-view canvas, branding watermark
+- Both routes resolve via `Workflow.shareId` (unique) and require `isPublic = true`
+- `/embed/*` ships with `Content-Security-Policy: frame-ancestors *` (set in `next.config.ts`) — do not block-list it; it is the only path explicitly meant to be framed
+- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark
+- Mermaid copy buttons (dashboard + shared view) wrap output in a fenced ` ```mermaid ` block so paste-into-README "just works"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Design state machines graphically, then export production-ready YAML, JSON, Type
 - **Styling Metadata** -- Set `bg_color`, `description`, `color`, `arrow_color` with a built-in color picker
 - **Undo / Redo** -- 50-step history with Cmd+Z / Cmd+Shift+Z
 - **Shareable Links** -- Generate read-only public links to share workflow designs
+- **Markdown-Ready Embeds** -- Copy a Mermaid block for GitHub READMEs or grab an `<iframe>` snippet to drop a live, interactive workflow into any docs site
 - **No Account Required** -- The editor is fully public. Sign in to unlock cloud save, versioning, and sharing
 
 ## Tech Stack
@@ -106,6 +107,7 @@ app/
   dashboard/                   # Protected user workspace
   auth/                        # Sign in / error pages
   w/[shareId]/page.tsx         # Public shared workflow view
+  embed/[shareId]/page.tsx     # Iframe-friendly read-only canvas (CSP allows any frame-ancestor)
   api/workflows/               # CRUD + sharing + versioning API
 
 components/
@@ -209,6 +211,7 @@ CI runs ESLint, Prettier, TypeScript checks, and a production build on every PR.
 - [x] `!php/const` and `!php/enum` YAML tag support
 - [x] Export to Mermaid diagram format (`stateDiagram-v2`)
 - [x] Workflow composition (nested sub-workflow nodes)
+- [x] Markdown-ready Mermaid copy + iframe embed for shared workflows
 
 ### In Progress
 

--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+    ReactFlow,
+    Background,
+    BackgroundVariant,
+    MiniMap,
+    ReactFlowProvider,
+    type Node,
+    type Edge,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import { Logo } from "@/components/ui/logo";
+import { StateNode } from "@/components/editor/nodes/StateNode";
+import { TransitionNode } from "@/components/editor/nodes/TransitionNode";
+import { SubWorkflowNode } from "@/components/editor/nodes/SubWorkflowNode";
+import { ConnectorEdge } from "@/components/editor/edges/ConnectorEdge";
+import { migrateGraphData } from "symflow/react-flow";
+
+const nodeTypes = {
+    state: StateNode,
+    transition: TransitionNode,
+    subworkflow: SubWorkflowNode,
+};
+
+const edgeTypes = {
+    connector: ConnectorEdge,
+};
+
+interface Props {
+    shareId: string;
+    name: string;
+    graphJson: Record<string, unknown>;
+    showMiniMap: boolean;
+    showBranding: boolean;
+}
+
+export function EmbeddedWorkflowView({
+    shareId,
+    name,
+    graphJson,
+    showMiniMap,
+    showBranding,
+}: Props) {
+    const rawNodes = (graphJson.nodes as Node[]) ?? [];
+    const rawEdges = (graphJson.edges as Edge[]) ?? [];
+    const { nodes, edges } = migrateGraphData({ nodes: rawNodes, edges: rawEdges });
+
+    return (
+        <div className="h-screen w-screen relative bg-[#0a0a14]">
+            <ReactFlowProvider>
+                <ReactFlow
+                    nodes={nodes}
+                    edges={edges}
+                    nodeTypes={nodeTypes}
+                    edgeTypes={edgeTypes}
+                    nodesDraggable={false}
+                    nodesConnectable={false}
+                    elementsSelectable={false}
+                    panOnDrag={true}
+                    zoomOnScroll={true}
+                    fitView
+                    proOptions={{ hideAttribution: true }}
+                >
+                    <Background
+                        variant={BackgroundVariant.Dots}
+                        gap={20}
+                        size={1}
+                        color="rgba(255,255,255,0.07)"
+                    />
+                    {showMiniMap && (
+                        <MiniMap
+                            className="!bg-[var(--glass-base)] !border !border-[var(--glass-border)] !rounded-[14px]"
+                            nodeColor="var(--glass-overlay)"
+                            maskColor="rgba(0,0,0,0.5)"
+                        />
+                    )}
+                </ReactFlow>
+            </ReactFlowProvider>
+
+            {showBranding && (
+                <a
+                    href={`/w/${shareId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`Open ${name} on SymFlowBuilder`}
+                    className="absolute bottom-3 left-3 z-30 flex items-center gap-1.5 px-2.5 py-1.5 rounded-[10px] bg-[var(--glass-base)] border border-[var(--glass-border)] backdrop-blur-xl text-[10px] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                    <Logo size={12} />
+                    <span className="font-medium">SymFlowBuilder</span>
+                </a>
+            )}
+        </div>
+    );
+}

--- a/app/embed/[shareId]/page.tsx
+++ b/app/embed/[shareId]/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { prisma } from "@symflowbuilder/db";
+import { notFound } from "next/navigation";
+import { EmbeddedWorkflowView } from "./EmbeddedWorkflowView";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ shareId: string }>;
+}): Promise<Metadata> {
+    const { shareId } = await params;
+    const workflow = await prisma.workflow.findUnique({
+        where: { shareId },
+        select: { name: true, isPublic: true },
+    });
+
+    if (!workflow || !workflow.isPublic) {
+        return { title: "Workflow Not Found" };
+    }
+
+    return {
+        title: `${workflow.name} — Embedded`,
+        robots: { index: false, follow: false },
+    };
+}
+
+export default async function EmbedWorkflowPage({
+    params,
+    searchParams,
+}: {
+    params: Promise<{ shareId: string }>;
+    searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+    const { shareId } = await params;
+    const query = await searchParams;
+
+    const workflow = await prisma.workflow.findUnique({
+        where: { shareId },
+        select: { name: true, graphJson: true, isPublic: true },
+    });
+
+    if (!workflow || !workflow.isPublic) {
+        notFound();
+    }
+
+    const showMiniMap = query.minimap !== "0";
+    const showBranding = query.branding !== "0";
+
+    return (
+        <EmbeddedWorkflowView
+            shareId={shareId}
+            name={workflow.name}
+            graphJson={workflow.graphJson as Record<string, unknown>}
+            showMiniMap={showMiniMap}
+            showBranding={showBranding}
+        />
+    );
+}

--- a/app/w/[shareId]/SharedWorkflowView.tsx
+++ b/app/w/[shareId]/SharedWorkflowView.tsx
@@ -110,7 +110,11 @@ export function SharedWorkflowView({
     const exportLabel = exportFormat === "yaml" ? "YAML" : "Mermaid";
 
     const handleCopyExport = async () => {
-        await navigator.clipboard.writeText(exportOutput);
+        const text =
+            exportFormat === "mermaid"
+                ? `\`\`\`mermaid\n${exportOutput}\n\`\`\``
+                : exportOutput;
+        await navigator.clipboard.writeText(text);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
     };

--- a/components/dashboard/export-workflow-button.tsx
+++ b/components/dashboard/export-workflow-button.tsx
@@ -51,9 +51,10 @@ export function ExportWorkflowButton({ name, graphJson }: ExportWorkflowButtonPr
     const cfg = FORMAT_CONFIG[format];
 
     const handleCopy = () => {
-        navigator.clipboard.writeText(output);
+        const text = format === "mermaid" ? `\`\`\`mermaid\n${output}\n\`\`\`` : output;
+        navigator.clipboard.writeText(text);
         setCopied(true);
-        toast.success(`${cfg.label} copied`);
+        toast.success(format === "mermaid" ? "Markdown copied" : `${cfg.label} copied`);
         setTimeout(() => setCopied(false), 2000);
     };
 

--- a/components/dashboard/share-workflow-button.tsx
+++ b/components/dashboard/share-workflow-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Share2, Link2, Link2Off, Copy, Check } from "lucide-react";
+import { Share2, Link2, Link2Off, Copy, Check, Code2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -25,10 +25,14 @@ export function ShareWorkflowButton({
     const [currentShareId, setCurrentShareId] = useState(shareId);
     const [loading, setLoading] = useState(false);
     const [copied, setCopied] = useState(false);
+    const [embedCopied, setEmbedCopied] = useState(false);
     const router = useRouter();
 
-    const shareUrl = currentShareId
-        ? `${typeof window !== "undefined" ? window.location.origin : ""}/w/${currentShareId}`
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const shareUrl = currentShareId ? `${origin}/w/${currentShareId}` : "";
+    const embedUrl = currentShareId ? `${origin}/embed/${currentShareId}` : "";
+    const embedSnippet = currentShareId
+        ? `<iframe src="${embedUrl}" width="100%" height="500" style="border:0;border-radius:14px" loading="lazy" title="SymFlowBuilder workflow"></iframe>`
         : "";
 
     const handleShare = async () => {
@@ -71,6 +75,13 @@ export function ShareWorkflowButton({
         setCopied(true);
         toast.success("Link copied");
         setTimeout(() => setCopied(false), 2000);
+    };
+
+    const handleCopyEmbed = () => {
+        navigator.clipboard.writeText(embedSnippet);
+        setEmbedCopied(true);
+        toast.success("Embed snippet copied");
+        setTimeout(() => setEmbedCopied(false), 2000);
     };
 
     return (
@@ -116,6 +127,35 @@ export function ShareWorkflowButton({
                                             <Copy className="w-3.5 h-3.5" />
                                         )}
                                     </Button>
+                                </div>
+                                <div className="flex flex-col gap-2">
+                                    <div className="flex items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
+                                        <Code2 className="w-3 h-3" />
+                                        Embed
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Input
+                                            value={embedSnippet}
+                                            readOnly
+                                            className="text-[10px] font-mono flex-1"
+                                        />
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={handleCopyEmbed}
+                                            className="shrink-0"
+                                        >
+                                            {embedCopied ? (
+                                                <Check className="w-3.5 h-3.5 text-[var(--success)]" />
+                                            ) : (
+                                                <Copy className="w-3.5 h-3.5" />
+                                            )}
+                                        </Button>
+                                    </div>
+                                    <p className="text-[10px] text-[var(--text-muted)]">
+                                        Drop into MDX, HTML, or any docs site that allows
+                                        iframes.
+                                    </p>
                                 </div>
                                 <div className="flex justify-between">
                                     <div className="flex items-center gap-1.5 text-[10px] text-[var(--success)]">

--- a/lib/data/blog-posts.ts
+++ b/lib/data/blog-posts.ts
@@ -9,6 +9,88 @@ export interface BlogPost {
 
 export const blogPosts: BlogPost[] = [
     {
+        slug: "embed-workflows-anywhere",
+        title: "Embed SymFlowBuilder Workflows in Any README, Doc, or Wiki",
+        date: "2026-04-28",
+        excerpt:
+            "Two new ways to put a live workflow next to the code it describes: a one-click Mermaid block for GitHub READMEs, and an iframe embed for docs sites that want pan, zoom, and minimap.",
+        tags: ["feature", "share", "embed", "mermaid", "documentation"],
+        content: `## Workflows belong next to the code they describe
+
+A Symfony workflow is documentation as much as it is configuration. The state machine for an order, an article, a moderation queue — that diagram answers more onboarding questions than half a wiki page. The problem has always been getting the diagram *into* the wiki page.
+
+This release adds two paths from a SymFlowBuilder workflow to wherever your team writes things down. Pick the one that matches the destination.
+
+## Path 1 — Copy a Mermaid block (works in GitHub READMEs)
+
+Open any workflow on the dashboard or on its public share page, click **Export**, switch to **Mermaid**, and hit **Copy**.
+
+What lands on your clipboard is not raw \`stateDiagram-v2\` text — it is already wrapped in a fenced block:
+
+\`\`\`text
+\\\`\\\`\\\`mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> draft
+    draft --> submitted: submit
+    submitted --> approved: approve [is_granted("ROLE_ADMIN")]
+    submitted --> rejected: reject
+    approved --> [*]
+\\\`\\\`\\\`
+\`\`\`
+
+Paste that block straight into a GitHub README, a GitLab MR description, an Obsidian note, a Notion page, or any other Markdown surface that renders Mermaid. No screenshots to keep in sync, no PNG drift, no broken alt text. The diagram updates the next time you re-export.
+
+If you want the raw \`.mmd\` (for embedding into your own tooling), the **Download** button still gives you the unwrapped version. Copy = Markdown-ready, Download = engine-ready.
+
+## Path 2 — Drop in an \`<iframe>\` (works in any docs site)
+
+Mermaid is great for static diagrams. But when you want pan, zoom, a minimap, and the actual node styling from your workflow — the kind of thing readers can scroll around in — you need the real canvas.
+
+Make any workflow public from the dashboard, open the share dialog, and you will now see an **Embed** snippet alongside the share link:
+
+\`\`\`html
+<iframe
+  src="https://symflowbuilder.com/embed/abc123def456"
+  width="100%"
+  height="500"
+  style="border:0;border-radius:14px"
+  loading="lazy"
+  title="SymFlowBuilder workflow"
+></iframe>
+\`\`\`
+
+That route — \`/embed/[shareId]\` — renders the same React Flow canvas you use in the editor, but with the chrome stripped: no header bar, no export drawer, no config dialog. Just the diagram, fit to view on load, with an interactive minimap in the corner and a small "SymFlowBuilder" watermark linking back to the live share page.
+
+Drop it into Docusaurus, MkDocs, Mintlify, Nextra, your Notion-as-docs setup, a Confluence page that allows iframes — anywhere HTML is allowed.
+
+### Tweak it with query params
+
+The embed accepts a couple of switches:
+
+- \`?minimap=0\` — hide the minimap (useful for small embeds)
+- \`?branding=0\` — hide the SymFlowBuilder watermark (please leave it on if you can — it is the only "credit" the project gets)
+
+### How it is actually allowed to be framed
+
+By default, modern browsers will refuse to render an iframe from another origin if the response sets \`X-Frame-Options\` or restrictive \`frame-ancestors\`. The new route does the opposite: it ships an explicit \`Content-Security-Policy: frame-ancestors *\` header, scoped only to \`/embed/*\`. The rest of the app stays as it was. You opt in to being framed by sharing a workflow; the rest of the surface area is untouched.
+
+## Pick the right path
+
+| You want… | Use |
+| --- | --- |
+| A diagram in a GitHub/GitLab README | **Mermaid copy** — renders natively, no iframe needed |
+| A diagram in a Markdown file rendered by a tool that does not support Mermaid | **Mermaid copy** — pastes as a fenced block, downgrades gracefully to monospace text |
+| Pan, zoom, minimap, real styling, in a docs site | **Iframe embed** — interactive, always up-to-date with the source workflow |
+| A static PNG/SVG for a slide deck | Coming next — see the roadmap |
+
+## What is next
+
+The natural follow-up is an SVG snapshot endpoint — \`/api/w/[shareId]/svg\` — that returns a rendered diagram in any markdown renderer that does not support Mermaid or iframes. That one needs a small addition to the [\`symflow\`](https://www.npmjs.com/package/symflow) engine to keep export functions consistent (string-builder pattern alongside YAML, JSON, TypeScript, Mermaid, and DOT). It is on the roadmap; ping the [issue tracker](https://github.com/vandetho/symflowbuilder/issues) if you have a use case that needs it sooner.
+
+In the meantime: design the workflow once, paste it everywhere it belongs.`,
+    },
+    {
         slug: "laravel-export-and-symflow-laravel",
         title: "Design Workflows Visually, Run Them in Laravel with symflow-laravel",
         date: "2026-04-24",

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,19 @@ const nextConfig: NextConfig = {
             },
         ],
     },
+    async headers() {
+        return [
+            {
+                source: "/embed/:path*",
+                headers: [
+                    {
+                        key: "Content-Security-Policy",
+                        value: "frame-ancestors *",
+                    },
+                ],
+            },
+        ];
+    },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- **Tier 1** — Mermaid copy buttons (dashboard export + shared view drawer) now wrap output in a fenced ` ```mermaid ` block. Paste straight into a GitHub README and it renders. Downloads stay raw `.mmd`.
- **Tier 2** — New `/embed/[shareId]` route renders a stripped-down React Flow canvas (no header, no export drawer, fit-to-view) suitable for `<iframe>`-ing into any docs site. Reuses existing `shareId`/`isPublic` gating; no new schema. Optional `?minimap=0` and `?branding=0` query params.
- Scoped CSP `frame-ancestors *` override in `next.config.ts` allows framing **only** on `/embed/*`. Rest of the app is untouched.
- Share dialog now exposes a copy-able `<iframe>` snippet alongside the share URL.
- README, CLAUDE.md, and a new blog post (`embed-workflows-anywhere`) document both paths.

## Test plan
- [ ] Make a workflow public from the dashboard
- [ ] Open the share dialog → confirm the iframe snippet appears and the copy button works
- [ ] Paste the iframe into a local HTML file → confirm canvas renders, pan/zoom/minimap work
- [ ] Try `?minimap=0` and `?branding=0` query params
- [ ] In the export drawer, switch to Mermaid → click Copy → paste into a GitHub README preview → confirm it renders as a Mermaid diagram
- [ ] Confirm the Download button still produces a raw `.mmd` (no fence)
- [ ] Confirm `/w/[shareId]` (full share view) still works as before
- [ ] Hit a non-public or non-existent shareId at `/embed/[shareId]` → confirm 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)