### PR TITLE
fix(editor): toolbar dropdown sizing and connect/reconnect dedupe

### DIFF
--- a/components/editor/EditorCanvas.tsx
+++ b/components/editor/EditorCanvas.tsx
@@ -123,16 +123,29 @@ function EditorCanvasInner() {
                 (sourceIsPlace && targetNode.type === "transition") ||
                 (sourceNode.type === "transition" && targetIsPlace)
             ) {
-                // State→Transition or Transition→State: add a single connector edge
-                setEdges((eds) => [
-                    ...eds,
-                    {
-                        id: uid("edge"),
-                        source: connection.source!,
-                        target: connection.target!,
-                        type: "connector",
-                    },
-                ]);
+                // State→Transition or Transition→State: add a single connector edge.
+                // Dedupe on (source, target) — React Flow keys edges by source/target,
+                // so a duplicate pair would collide even with a unique edge id.
+                setEdges((eds) => {
+                    if (
+                        eds.some(
+                            (e) =>
+                                e.source === connection.source &&
+                                e.target === connection.target
+                        )
+                    ) {
+                        return eds;
+                    }
+                    return [
+                        ...eds,
+                        {
+                            id: uid("edge"),
+                            source: connection.source!,
+                            target: connection.target!,
+                            type: "connector",
+                        },
+                    ];
+                });
                 snapshot();
             }
             // Block transition→transition connections (do nothing)
@@ -256,7 +269,17 @@ function EditorCanvasInner() {
     const onReconnect: OnReconnect = useCallback(
         (oldEdge: Edge, newConnection: Connection) => {
             edgeReconnectSuccessful.current = true;
-            setEdges((eds) => reconnectEdge(oldEdge, newConnection, eds));
+            setEdges((eds) => {
+                // Reject reconnect that would duplicate an existing (source, target) pair
+                const wouldDuplicate = eds.some(
+                    (e) =>
+                        e.id !== oldEdge.id &&
+                        e.source === newConnection.source &&
+                        e.target === newConnection.target
+                );
+                if (wouldDuplicate) return eds;
+                return reconnectEdge(oldEdge, newConnection, eds);
+            });
             snapshot();
         },
         [setEdges, snapshot]
@@ -295,9 +318,14 @@ function EditorCanvasInner() {
             if (!connectingFrom.current) return;
 
             const target = (event as MouseEvent).target as HTMLElement;
-            // Only create node if dropped on the pane (not on another node/handle)
-            const isPane = target.closest(".react-flow__pane");
-            if (!isPane) {
+            // Only create a node if the drop landed on empty pane — not on an
+            // existing node or a connection handle. In React Flow v12 nodes are
+            // descendants of `.react-flow__pane`, so `closest(".react-flow__pane")`
+            // alone is not enough; we must also reject node/handle drops.
+            const droppedOnNode = !!target.closest(".react-flow__node");
+            const droppedOnHandle = !!target.closest(".react-flow__handle");
+            const droppedOnPane = !!target.closest(".react-flow__pane");
+            if (droppedOnNode || droppedOnHandle || !droppedOnPane) {
                 connectingFrom.current = null;
                 return;
             }
@@ -309,9 +337,13 @@ function EditorCanvasInner() {
 
             const position = screenToFlowPosition({ x: clientX, y: clientY });
             const fromNode = nodes.find((n) => n.id === connectingFrom.current!.nodeId);
+            if (!fromNode) {
+                connectingFrom.current = null;
+                return;
+            }
             const isSource = connectingFrom.current.handleType === "source";
 
-            if (fromNode?.type === "transition") {
+            if (fromNode.type === "transition") {
                 // Dragging from a transition node → create a new state node + 1 edge
                 const newStateId = uid("state");
                 const existingStateLabels = nodes
@@ -348,8 +380,8 @@ function EditorCanvasInner() {
                     .filter((n) => n.type === "transition")
                     .map((n) => (n.data as unknown as TransitionNodeData).label);
 
-                const midX = (fromNode!.position.x + position.x) / 2;
-                const midY = (fromNode!.position.y + position.y) / 2;
+                const midX = (fromNode.position.x + position.x) / 2;
+                const midY = (fromNode.position.y + position.y) / 2;
 
                 addNode({
                     id: transitionId,
@@ -374,8 +406,8 @@ function EditorCanvasInner() {
                     } satisfies StateNodeData,
                 });
 
-                const sourceId = isSource ? fromNode!.id : newStateId;
-                const targetId = isSource ? newStateId : fromNode!.id;
+                const sourceId = isSource ? fromNode.id : newStateId;
+                const targetId = isSource ? newStateId : fromNode.id;
                 setEdges((eds) => [
                     ...eds,
                     {

--- a/components/editor/panels/EditorToolbar.tsx
+++ b/components/editor/panels/EditorToolbar.tsx
@@ -457,7 +457,7 @@ export function EditorToolbar() {
                             variant="ghost"
                             size="sm"
                             onClick={handleImportFile}
-                            className="rounded-r-none border-r-0"
+                            className="rounded-r-none border-r-0!"
                         >
                             <Upload className="w-3.5 h-3.5" />
                             Import
@@ -465,7 +465,7 @@ export function EditorToolbar() {
                         <Button
                             variant="ghost"
                             size="sm"
-                            className="rounded-l-none px-1.5 h-full"
+                            className="rounded-l-none px-1.5"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 setOpenDropdown(
@@ -483,25 +483,25 @@ export function EditorToolbar() {
                             </svg>
                         </Button>
                         {openDropdown === "import" && (
-                            <div className="absolute top-full left-0 mt-1 glass-strong border border-[var(--glass-border)] rounded-[10px] overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.4)] min-w-[180px] z-50">
+                            <div className="absolute top-full right-0 mt-1 glass-strong border border-[var(--glass-border)] rounded-[10px] overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.4)] z-50">
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         handleImportFile();
                                     }}
                                 >
-                                    <Upload className="w-3.5 h-3.5" />
+                                    <Upload className="w-3.5 h-3.5 shrink-0" />
                                     From file (.yaml, .json)
                                 </button>
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         setShowImportUrl(true);
                                     }}
                                 >
-                                    <Link2 className="w-3.5 h-3.5" />
+                                    <Link2 className="w-3.5 h-3.5 shrink-0" />
                                     From URL
                                 </button>
                             </div>
@@ -521,7 +521,7 @@ export function EditorToolbar() {
                         <Button
                             variant="default"
                             size="sm"
-                            className="rounded-l-none border-l border-white/20 px-1.5 h-full"
+                            className="rounded-l-none border-l border-white/20 px-1.5"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 setOpenDropdown(
@@ -539,65 +539,65 @@ export function EditorToolbar() {
                             </svg>
                         </Button>
                         {openDropdown === "export" && (
-                            <div className="absolute top-full left-0 mt-1 glass-strong border border-[var(--glass-border)] rounded-[10px] overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.4)] min-w-[140px] z-50">
+                            <div className="absolute top-full right-0 mt-1 glass-strong border border-[var(--glass-border)] rounded-[10px] overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.4)] z-50">
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         doExport("yaml");
                                     }}
                                 >
-                                    <FileDown className="w-3.5 h-3.5" />
+                                    <FileDown className="w-3.5 h-3.5 shrink-0" />
                                     YAML
                                 </button>
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         doExport("json");
                                     }}
                                 >
-                                    <FileJson className="w-3.5 h-3.5" />
+                                    <FileJson className="w-3.5 h-3.5 shrink-0" />
                                     JSON
                                 </button>
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         doExport("typescript");
                                     }}
                                 >
-                                    <FileCode className="w-3.5 h-3.5" />
+                                    <FileCode className="w-3.5 h-3.5 shrink-0" />
                                     TypeScript
                                 </button>
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         doExport("mermaid");
                                     }}
                                 >
-                                    <GitBranch className="w-3.5 h-3.5" />
+                                    <GitBranch className="w-3.5 h-3.5 shrink-0" />
                                     Mermaid
                                 </button>
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         doExport("dot");
                                     }}
                                 >
-                                    <CircleDot className="w-3.5 h-3.5" />
+                                    <CircleDot className="w-3.5 h-3.5 shrink-0" />
                                     DOT (Graphviz)
                                 </button>
                                 <button
-                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                    className="w-full flex items-center gap-2 px-3 py-2 text-xs whitespace-nowrap text-[var(--text-secondary)] hover:bg-[var(--glass-hover)] hover:text-[var(--text-primary)] transition-colors"
                                     onClick={() => {
                                         setOpenDropdown(null);
                                         doExport("php");
                                     }}
                                 >
-                                    <Gem className="w-3.5 h-3.5" />
+                                    <Gem className="w-3.5 h-3.5 shrink-0" />
                                     PHP (Laravel)
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary
- Export dropdown's "DOT (Graphviz)" no longer wraps onto two lines; items use `whitespace-nowrap` and the menu auto-sizes to its widest label. Both Import/Export menus now anchor to the right so they grow toward the canvas, not off-screen.
- Split-button caret matches the main button height (`h-full` was collapsing against the auto-height flex parent). The Import seam no longer renders a doubled border — `glass-sm` uses a `border` shorthand in `@layer utilities` that was overriding `border-r-0`; forced with Tailwind v4's `!` suffix.
- `onConnectEnd`: in React Flow v12 `.react-flow__pane` wraps the viewport, so `closest(".react-flow__pane")` matched even when the user dropped on a node. That made transition→transition (or any node-to-node) drag silently auto-create a stray transition + state. Now we explicitly reject drops landing on `.react-flow__node` / `.react-flow__handle`.
- `onConnect` and `onReconnect`: dedupe by `(source, target)`. React Flow keys edge components by source/target, so duplicate pairs trigger React's "Encountered two children with the same key" warning even when the new edge has a unique `id`.

## Test plan
- [ ] Open `/editor`, open the Export menu — "DOT (Graphviz)" sits on a single line.
- [ ] Import/Export split buttons render as one pill with a single 1px divider.
- [ ] Drag a connection from a transition handle onto another transition's body — no stray nodes appear.
- [ ] Drag a second connection between an already-connected (state, transition) pair — no duplicate-key warning, no duplicate edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)