### PR TITLE
feat(simulator): playable scenarios with subject, patches, and mock HTTP

### DIFF
--- a/app/api/workflows/[id]/route.ts
+++ b/app/api/workflows/[id]/route.ts
@@ -1,5 +1,5 @@
 import { auth } from "@/auth";
-import { prisma } from "@symflowbuilder/db";
+import { prisma, Prisma } from "@symflowbuilder/db";
 import {
     getWorkflowAccess,
     canView,
@@ -63,6 +63,12 @@ export async function PUT(
                 type: data.type,
                 graphJson: data.graphJson as object | undefined,
                 yamlCache: data.yamlCache,
+                simulationConfig:
+                    data.simulationConfig === undefined
+                        ? undefined
+                        : data.simulationConfig === null
+                          ? Prisma.JsonNull
+                          : (data.simulationConfig as Prisma.InputJsonValue),
             },
         });
 

--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@symflowbuilder/db";
+import { prisma, Prisma } from "@symflowbuilder/db";
 import type { NextRequest } from "next/server";
 import { requireUserId } from "@/lib/workflow-auth";
 import { createWorkflowSchema } from "@/lib/schemas/workflow";
@@ -52,6 +52,10 @@ export async function POST(request: NextRequest) {
                 type: data.type ?? "workflow",
                 graphJson: (data.graphJson ?? { nodes: [], edges: [] }) as object,
                 yamlCache: data.yamlCache,
+                simulationConfig:
+                    data.simulationConfig === null || data.simulationConfig === undefined
+                        ? Prisma.JsonNull
+                        : (data.simulationConfig as Prisma.InputJsonValue),
             },
         });
         return Response.json(workflow, { status: 201 });

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -48,6 +48,7 @@ export default function EditWorkflowPage({
                         supports: "App\\Entity\\MyEntity",
                         property: "currentState",
                     },
+                    simulationConfig: workflow.simulationConfig ?? null,
                 });
             } catch {
                 setError("Failed to load workflow");

--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import {
     ReactFlow,
     Background,
@@ -10,12 +11,18 @@ import {
     type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { Play, Square } from "lucide-react";
 
 import { Logo } from "@/components/ui/logo";
+import { Button } from "@/components/ui/button";
 import { StateNode } from "@/components/editor/nodes/StateNode";
 import { TransitionNode } from "@/components/editor/nodes/TransitionNode";
 import { SubWorkflowNode } from "@/components/editor/nodes/SubWorkflowNode";
 import { ConnectorEdge } from "@/components/editor/edges/ConnectorEdge";
+import { SimulatorPanel } from "@/components/editor/panels/SimulatorPanel";
+import { useSimulatorStore } from "@/stores/simulator";
+import type { WorkflowMeta } from "symflow";
+import type { SimulationConfig } from "@/types/simulation";
 import { migrateGraphData } from "symflow/react-flow";
 
 const nodeTypes = {
@@ -31,21 +38,75 @@ const edgeTypes = {
 interface Props {
     shareId: string;
     name: string;
+    type: string;
+    symfonyVersion: string;
     graphJson: Record<string, unknown>;
+    simulationConfig?: Record<string, unknown> | null;
     showMiniMap: boolean;
     showBranding: boolean;
+    autoPlay: boolean;
 }
 
 export function EmbeddedWorkflowView({
     shareId,
     name,
+    type,
+    symfonyVersion,
     graphJson,
+    simulationConfig,
     showMiniMap,
     showBranding,
+    autoPlay,
 }: Props) {
     const rawNodes = (graphJson.nodes as Node[]) ?? [];
     const rawEdges = (graphJson.edges as Edge[]) ?? [];
     const { nodes, edges } = migrateGraphData({ nodes: rawNodes, edges: rawEdges });
+
+    const meta = (graphJson.meta as WorkflowMeta) ?? {
+        name,
+        symfonyVersion,
+        type,
+        marking_store: "method",
+        initial_marking: [],
+        supports: "App\\Entity\\MyEntity",
+        property: "currentState",
+    };
+
+    const simActive = useSimulatorStore((s) => s.active);
+    const simInitialize = useSimulatorStore((s) => s.initialize);
+    const simActivate = useSimulatorStore((s) => s.activate);
+    const simDeactivate = useSimulatorStore((s) => s.deactivate);
+
+    useEffect(() => {
+        if (autoPlay && !simActive) {
+            simInitialize(
+                nodes,
+                edges,
+                meta,
+                (simulationConfig as SimulationConfig | null) ?? null
+            );
+            simActivate();
+        }
+        return () => {
+            simDeactivate();
+        };
+        // Run once on mount; deactivate on unmount.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleToggle = () => {
+        if (simActive) {
+            simDeactivate();
+        } else {
+            simInitialize(
+                nodes,
+                edges,
+                meta,
+                (simulationConfig as SimulationConfig | null) ?? null
+            );
+            simActivate();
+        }
+    };
 
     return (
         <div className="h-screen w-screen relative bg-[#0a0a14]">
@@ -78,6 +139,28 @@ export function EmbeddedWorkflowView({
                     )}
                 </ReactFlow>
             </ReactFlowProvider>
+
+            <div className="absolute top-3 left-3 z-30">
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className={`gap-1.5 backdrop-blur-xl border ${
+                        simActive
+                            ? "text-[var(--success)] bg-[var(--success-dim)] border-[var(--success)]"
+                            : "bg-[var(--glass-base)] border-[var(--glass-border)]"
+                    }`}
+                    onClick={handleToggle}
+                >
+                    {simActive ? (
+                        <Square className="w-3.5 h-3.5" />
+                    ) : (
+                        <Play className="w-3.5 h-3.5" />
+                    )}
+                    {simActive ? "Stop" : "Run scenario"}
+                </Button>
+            </div>
+
+            <SimulatorPanel />
 
             {showBranding && (
                 <a

--- a/app/embed/[shareId]/page.tsx
+++ b/app/embed/[shareId]/page.tsx
@@ -36,7 +36,14 @@ export default async function EmbedWorkflowPage({
 
     const workflow = await prisma.workflow.findUnique({
         where: { shareId },
-        select: { name: true, graphJson: true, isPublic: true },
+        select: {
+            name: true,
+            type: true,
+            symfonyVersion: true,
+            graphJson: true,
+            simulationConfig: true,
+            isPublic: true,
+        },
     });
 
     if (!workflow || !workflow.isPublic) {
@@ -45,14 +52,21 @@ export default async function EmbedWorkflowPage({
 
     const showMiniMap = query.minimap !== "0";
     const showBranding = query.branding !== "0";
+    const autoPlay = query.play === "1";
 
     return (
         <EmbeddedWorkflowView
             shareId={shareId}
             name={workflow.name}
+            type={workflow.type}
+            symfonyVersion={workflow.symfonyVersion}
             graphJson={workflow.graphJson as Record<string, unknown>}
+            simulationConfig={
+                (workflow.simulationConfig as Record<string, unknown> | null) ?? null
+            }
             showMiniMap={showMiniMap}
             showBranding={showBranding}
+            autoPlay={autoPlay}
         />
     );
 }

--- a/app/w/[shareId]/SharedWorkflowView.tsx
+++ b/app/w/[shareId]/SharedWorkflowView.tsx
@@ -58,11 +58,14 @@ const edgeTypes = {
     connector: ConnectorEdge,
 };
 
+import type { SimulationConfig } from "@/types/simulation";
+
 interface Props {
     name: string;
     type: string;
     symfonyVersion: string;
     graphJson: Record<string, unknown>;
+    simulationConfig?: Record<string, unknown> | null;
     workflowId?: string;
 }
 
@@ -71,6 +74,7 @@ export function SharedWorkflowView({
     type,
     symfonyVersion,
     graphJson,
+    simulationConfig,
     workflowId,
 }: Props) {
     const router = useRouter();
@@ -172,7 +176,12 @@ export function SharedWorkflowView({
                             if (simActive) {
                                 simDeactivate();
                             } else {
-                                simInitialize(nodes, edges, meta);
+                                simInitialize(
+                                    nodes,
+                                    edges,
+                                    meta,
+                                    (simulationConfig as SimulationConfig | null) ?? null
+                                );
                                 simActivate();
                             }
                         }}

--- a/app/w/[shareId]/page.tsx
+++ b/app/w/[shareId]/page.tsx
@@ -62,6 +62,9 @@ export default async function SharedWorkflowPage({
             type={workflow.type}
             symfonyVersion={workflow.symfonyVersion}
             graphJson={workflow.graphJson as Record<string, unknown>}
+            simulationConfig={
+                (workflow.simulationConfig as Record<string, unknown> | null) ?? null
+            }
             workflowId={isOwner ? workflow.id : undefined}
         />
     );

--- a/components/editor/panels/EditorToolbar.tsx
+++ b/components/editor/panels/EditorToolbar.tsx
@@ -56,13 +56,22 @@ function SimulateButton() {
     const initialize = useSimulatorStore((s) => s.initialize);
     const activate = useSimulatorStore((s) => s.activate);
     const deactivate = useSimulatorStore((s) => s.deactivate);
-    const { nodes, edges, workflowMeta } = useEditorStore();
+    const configDirty = useSimulatorStore((s) => s.configDirty);
+    const simConfig = useSimulatorStore((s) => s.config);
+    const markConfigSaved = useSimulatorStore((s) => s.markConfigSaved);
+    const { nodes, edges, workflowMeta, simulationConfig, setSimulationConfig } =
+        useEditorStore();
 
     const handleToggle = () => {
         if (simActive) {
+            // Persist scenario edits back to editor store on stop
+            if (configDirty) {
+                setSimulationConfig(simConfig);
+                markConfigSaved();
+            }
             deactivate();
         } else {
-            initialize(nodes, edges, workflowMeta);
+            initialize(nodes, edges, workflowMeta, simulationConfig);
             activate();
         }
     };

--- a/components/editor/panels/SimulatorPanel.tsx
+++ b/components/editor/panels/SimulatorPanel.tsx
@@ -1,22 +1,1044 @@
 "use client";
 
-import { useEffect, useRef, useCallback } from "react";
-import { Play, RotateCcw, X, SkipBack, Pause, ShieldOff, Shield } from "lucide-react";
+import { useEffect, useRef, useCallback, useMemo, useState } from "react";
+import {
+    Play,
+    RotateCcw,
+    X,
+    SkipBack,
+    Pause,
+    ShieldOff,
+    Shield,
+    FileText,
+    ListChecks,
+    SearchCode,
+    Plus,
+    Trash2,
+    Sparkles,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Select, SelectItem } from "@/components/ui/select";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { useSimulatorStore } from "@/stores/simulator";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useSimulatorStore, type SimulationStep } from "@/stores/simulator";
+import type { FieldPatch, JsonValue, TransitionEffect } from "@/types/simulation";
+import { diffPaths } from "@/lib/simulation/apply-effect";
+import { SIMULATION_TEMPLATES } from "@/lib/simulation/templates";
 
-export function SimulatorPanel() {
+function formatJson(value: unknown): string {
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return "{}";
+    }
+}
+
+function parseLiteral(input: string): JsonValue {
+    const trimmed = input.trim();
+    if (trimmed === "") return "";
+    if (trimmed === "null") return null;
+    if (trimmed === "true") return true;
+    if (trimmed === "false") return false;
+    if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+    if (
+        (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+        (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
+        (trimmed.startsWith('"') && trimmed.endsWith('"'))
+    ) {
+        try {
+            return JSON.parse(trimmed);
+        } catch {
+            return input;
+        }
+    }
+    return input;
+}
+
+function formatValue(value: JsonValue): string {
+    if (typeof value === "string") return value;
+    if (value === null) return "null";
+    return JSON.stringify(value);
+}
+
+// Re-sync a JSON-textarea draft from a parent value WITHOUT clobbering local
+// typing. Returns the draft to display: the current draft if it semantically
+// matches the parent (or is mid-edit invalid), otherwise the formatted parent.
+// This is what prevents cursor jumps when typing `{` Enter `}` produces valid
+// JSON and the parent echoes back a re-stringified version.
+function syncJsonDraft(
+    current: string,
+    parent: JsonValue | undefined,
+    treatEmptyAs: JsonValue | undefined = undefined
+): string {
+    let parsedCurrent: JsonValue | undefined;
+    try {
+        parsedCurrent = current.trim() === "" ? treatEmptyAs : JSON.parse(current);
+    } catch {
+        return current; // mid-edit invalid JSON — keep typing intact
+    }
+    if (JSON.stringify(parsedCurrent) === JSON.stringify(parent)) {
+        return current;
+    }
+    if (parent === undefined) return "";
+    return formatJson(parent);
+}
+
+function TabButton({
+    icon: Icon,
+    label,
+    active,
+    onClick,
+    badge,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    active: boolean;
+    onClick: () => void;
+    badge?: number;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-[10px] font-mono uppercase tracking-wider transition-colors border-b-2 ${
+                active
+                    ? "text-[var(--accent-bright)] border-[var(--accent-bright)]"
+                    : "text-[var(--text-muted)] border-transparent hover:text-[var(--text-secondary)]"
+            }`}
+        >
+            <Icon className="w-3 h-3" />
+            {label}
+            {badge !== undefined && badge > 0 && (
+                <span className="text-[8px] px-1 py-px rounded bg-[var(--accent-dim)] text-[var(--accent-bright)] border border-[var(--accent-border)]">
+                    {badge}
+                </span>
+            )}
+        </button>
+    );
+}
+
+function StepsTab() {
     const {
-        active,
         marking,
         enabledTransitions,
         history,
         analysis,
         blockedGuards,
+        autoPlaying,
+        applyTransition,
+        toggleGuard,
+        engine,
+        setSelectedStep,
+        setTab,
+    } = useSimulatorStore();
+
+    const activePlaces = Object.entries(marking)
+        .filter(([, count]) => count > 0)
+        .map(([name, count]) => ({ name, count }));
+
+    const isDeadEnd = enabledTransitions.length === 0;
+
+    const guardedTransitions = engine
+        ? engine.getDefinition().transitions.filter((t) => t.guard)
+        : [];
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Current State
+                </span>
+                <div className="flex flex-wrap gap-1.5">
+                    {activePlaces.map(({ name, count }) => {
+                        const pa = analysis?.places[name];
+                        const hasXorSplit = pa?.patterns.includes("xor-split");
+                        const hasOrSplit = pa?.patterns.includes("or-split");
+                        const hasXorJoin = pa?.patterns.includes("xor-join");
+                        const hasOrJoin = pa?.patterns.includes("or-join");
+                        const patternHint = hasXorSplit
+                            ? "XOR"
+                            : hasOrSplit
+                              ? "OR"
+                              : hasXorJoin
+                                ? "XOR-JOIN"
+                                : hasOrJoin
+                                  ? "MERGE"
+                                  : null;
+                        return (
+                            <Badge
+                                key={name}
+                                variant="default"
+                                className="text-[11px] font-mono bg-[var(--success-dim)] text-[var(--success)] border-[var(--success)] gap-1"
+                            >
+                                {name}
+                                {count > 1 && ` ×${count}`}
+                                {patternHint && (
+                                    <span className="text-[8px] px-1 py-px rounded bg-[var(--warning-dim)] text-[var(--warning)] border border-[rgba(251,191,36,0.2)]">
+                                        {patternHint}
+                                    </span>
+                                )}
+                            </Badge>
+                        );
+                    })}
+                    {activePlaces.length === 0 && (
+                        <span className="text-[11px] text-[var(--text-disabled)] font-mono">
+                            no active places
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            {guardedTransitions.length > 0 && (
+                <>
+                    <Separator />
+                    <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                            Guards
+                        </span>
+                        <div className="flex flex-col gap-1">
+                            {guardedTransitions.map((t) => {
+                                const isBlocked = blockedGuards[t.name];
+                                return (
+                                    <div
+                                        key={t.name}
+                                        className="flex items-center gap-2 text-[10px] font-mono"
+                                    >
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className={`h-5 w-5 ${isBlocked ? "text-[var(--danger)]" : "text-[var(--success)]"}`}
+                                                    onClick={() => toggleGuard(t.name)}
+                                                >
+                                                    {isBlocked ? (
+                                                        <ShieldOff className="w-3 h-3" />
+                                                    ) : (
+                                                        <Shield className="w-3 h-3" />
+                                                    )}
+                                                </Button>
+                                            </TooltipTrigger>
+                                            <TooltipContent side="right">
+                                                {isBlocked
+                                                    ? "Guard is blocked — click to allow"
+                                                    : "Guard passes — click to block"}
+                                            </TooltipContent>
+                                        </Tooltip>
+                                        <span
+                                            className={
+                                                isBlocked
+                                                    ? "text-[var(--danger)] line-through"
+                                                    : "text-[var(--text-secondary)]"
+                                            }
+                                        >
+                                            {t.name}
+                                        </span>
+                                        <span className="text-[var(--text-muted)] truncate max-w-[200px]">
+                                            {t.guard}
+                                        </span>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                </>
+            )}
+
+            <Separator />
+
+            <div className="flex flex-col gap-1.5">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Available Transitions
+                </span>
+                {isDeadEnd ? (
+                    <span className="text-[11px] text-[var(--warning)] font-mono">
+                        Dead end — no transitions available
+                    </span>
+                ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                        {enabledTransitions.map((t) => {
+                            const ta = analysis?.transitions[t.name];
+                            const patternLabel =
+                                ta?.pattern === "and-join"
+                                    ? "AND"
+                                    : ta?.pattern === "and-split"
+                                      ? "FORK"
+                                      : ta?.pattern === "and-split-join"
+                                        ? "AND+FORK"
+                                        : null;
+                            return (
+                                <Button
+                                    key={t.name}
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 text-[11px] font-mono border border-[var(--success-dim)] text-[var(--success)] hover:bg-[var(--success-dim)] gap-1"
+                                    onClick={() => applyTransition(t.name)}
+                                    disabled={autoPlaying}
+                                >
+                                    {t.name}
+                                    {patternLabel && (
+                                        <span className="text-[8px] px-1 py-px rounded bg-[var(--accent-dim)] text-[var(--accent-bright)] border border-[var(--accent-border)]">
+                                            {patternLabel}
+                                        </span>
+                                    )}
+                                </Button>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+
+            {history.length > 0 && (
+                <>
+                    <Separator />
+                    <div className="flex flex-col gap-1">
+                        <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                            History
+                        </span>
+                        <div className="flex flex-col gap-0.5 max-h-[140px] overflow-auto">
+                            {[...history]
+                                .map((step, i) => ({ step, originalIndex: i }))
+                                .reverse()
+                                .map(({ step, originalIndex }) => {
+                                    const fromPlaces = Object.entries(step.fromMarking)
+                                        .filter(([, c]) => c > 0)
+                                        .map(([n]) => n);
+                                    const toPlaces = Object.entries(step.toMarking)
+                                        .filter(([, c]) => c > 0)
+                                        .map(([n]) => n);
+                                    const changedPaths = diffPaths(
+                                        step.subjectBefore,
+                                        step.subjectAfter
+                                    );
+                                    return (
+                                        <button
+                                            type="button"
+                                            key={originalIndex}
+                                            onClick={() => {
+                                                setSelectedStep(originalIndex);
+                                                setTab("inspector");
+                                            }}
+                                            className="text-[10px] font-mono text-[var(--text-secondary)] flex items-center gap-1 hover:bg-[rgba(255,255,255,0.04)] rounded px-1 py-0.5 text-left cursor-pointer"
+                                        >
+                                            <span className="text-[var(--text-muted)] w-4 text-right shrink-0">
+                                                {originalIndex + 1}.
+                                            </span>
+                                            <span className="text-[var(--accent-bright)]">
+                                                {step.transitionName}
+                                            </span>
+                                            <span className="text-[var(--text-muted)]">
+                                                :
+                                            </span>
+                                            <span>{fromPlaces.join(", ")}</span>
+                                            <span className="text-[var(--text-muted)]">
+                                                →
+                                            </span>
+                                            <span>{toPlaces.join(", ")}</span>
+                                            {changedPaths.length > 0 && (
+                                                <span className="text-[8px] px-1 py-px rounded bg-[var(--success-dim)] text-[var(--success)] border border-[var(--success)]">
+                                                    {changedPaths.length} changes
+                                                </span>
+                                            )}
+                                            {step.resolvedRequest && (
+                                                <span
+                                                    className={`text-[8px] px-1 py-px rounded font-mono ${methodColor(step.resolvedRequest.method)}`}
+                                                >
+                                                    {step.resolvedRequest.method}
+                                                </span>
+                                            )}
+                                        </button>
+                                    );
+                                })}
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+function ScenarioTab() {
+    const {
+        config,
+        engine,
+        history,
+        setSubject,
+        setEffect,
+        addEffectPatch,
+        updateEffectPatch,
+        removeEffectPatch,
+        loadTemplate,
+    } = useSimulatorStore();
+
+    const [subjectDraft, setSubjectDraft] = useState(() => formatJson(config.subject));
+    const [subjectError, setSubjectError] = useState<string | null>(null);
+
+    useEffect(() => {
+        // Only re-sync when the external value differs semantically — preserves
+        // the user's whitespace and indentation while typing, only resets on
+        // template load.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setSubjectDraft((current) =>
+            syncJsonDraft(current, config.subject as JsonValue, {})
+        );
+    }, [config.subject]);
+
+    const transitionNames = useMemo(
+        () => engine?.getDefinition().transitions.map((t) => t.name) ?? [],
+        [engine]
+    );
+
+    const handleSubjectChange = (next: string) => {
+        setSubjectDraft(next);
+        try {
+            const parsed = JSON.parse(next || "{}");
+            if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+                setSubjectError("Subject must be a JSON object");
+                return;
+            }
+            setSubjectError(null);
+            setSubject(parsed);
+        } catch (e) {
+            setSubjectError(e instanceof Error ? e.message : "Invalid JSON");
+        }
+    };
+
+    const generateFromPlaces = () => {
+        if (!engine) return;
+        const places = engine.getDefinition().places.map((p) => p.name);
+        const next: Record<string, JsonValue> = { ...config.subject };
+        for (const place of places) {
+            if (!(place in next)) next[place] = false;
+        }
+        setSubjectDraft(formatJson(next));
+        setSubject(next);
+    };
+
+    const matchTemplate = (id: string) => {
+        const tpl = SIMULATION_TEMPLATES.find((t) => t.id === id);
+        if (!tpl) return;
+        loadTemplate(tpl.config);
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1 p-3 rounded-[10px] border border-[var(--accent-border)] bg-[var(--accent-dim)]">
+                <span className="text-[11px] font-medium text-[var(--accent-bright)]">
+                    What is a scenario?
+                </span>
+                <span className="text-[10px] text-[var(--text-secondary)] leading-relaxed">
+                    A scenario is the <em>data</em> flowing through your workflow — an
+                    article, an order, a document. Define a starting subject, declare how
+                    each transition mutates it, and optionally attach a mock API request.
+                    Then go to <strong>Steps</strong> to walk through it and{" "}
+                    <strong>Inspector</strong> to see the diff.
+                </span>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Start with a template
+                </span>
+                <div className="flex flex-col gap-1.5">
+                    {SIMULATION_TEMPLATES.map((tpl) => (
+                        <button
+                            key={tpl.id}
+                            type="button"
+                            onClick={() => matchTemplate(tpl.id)}
+                            className="flex items-start gap-2 p-2 rounded-[10px] border border-[var(--glass-border)] bg-[rgba(255,255,255,0.02)] hover:border-[var(--accent-border)] hover:bg-[var(--accent-dim)] transition-colors text-left"
+                        >
+                            <Sparkles className="w-3.5 h-3.5 text-[var(--accent-bright)] mt-0.5 shrink-0" />
+                            <div className="flex flex-col gap-0.5 min-w-0">
+                                <span className="text-[11px] font-medium text-[var(--text-primary)]">
+                                    {tpl.name}
+                                </span>
+                                <span className="text-[10px] text-[var(--text-secondary)] leading-relaxed">
+                                    {tpl.description}
+                                </span>
+                            </div>
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                    <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                        Starting Subject
+                    </span>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 text-[9px] gap-1"
+                        onClick={generateFromPlaces}
+                    >
+                        <Sparkles className="w-3 h-3" />
+                        From places
+                    </Button>
+                </div>
+                <Textarea
+                    value={subjectDraft}
+                    onChange={(e) => handleSubjectChange(e.target.value)}
+                    rows={6}
+                    className="text-[10px]"
+                    spellCheck={false}
+                    disabled={history.length > 0}
+                />
+                {subjectError ? (
+                    <span className="text-[9px] text-[var(--danger)] font-mono">
+                        {subjectError}
+                    </span>
+                ) : (
+                    history.length > 0 && (
+                        <span className="text-[9px] text-[var(--text-muted)] font-mono">
+                            Reset the simulation to edit the starting subject
+                        </span>
+                    )
+                )}
+            </div>
+
+            <Separator />
+
+            <div className="flex flex-col gap-2">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Transition Effects
+                </span>
+                {transitionNames.length === 0 && (
+                    <span className="text-[10px] text-[var(--text-disabled)] font-mono">
+                        No transitions defined yet
+                    </span>
+                )}
+                {transitionNames.map((name) => {
+                    const effect = config.effects?.[name];
+                    const patches = effect?.patches ?? [];
+                    return (
+                        <div
+                            key={name}
+                            className="flex flex-col gap-1.5 p-2 rounded-[10px] border border-[var(--glass-border)] bg-[rgba(255,255,255,0.02)]"
+                        >
+                            <div className="flex items-center justify-between">
+                                <span className="text-[11px] font-mono text-[var(--accent-bright)]">
+                                    {name}
+                                </span>
+                                <div className="flex items-center gap-1">
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-6 text-[9px] gap-1"
+                                        onClick={() =>
+                                            addEffectPatch(name, {
+                                                path: "",
+                                                value: "",
+                                                op: "set",
+                                            })
+                                        }
+                                    >
+                                        <Plus className="w-3 h-3" />
+                                        Patch
+                                    </Button>
+                                    {!effect?.mockRequest && (
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            className="h-6 text-[9px] gap-1"
+                                            onClick={() =>
+                                                setEffect(name, {
+                                                    ...(effect ?? {}),
+                                                    mockRequest: {
+                                                        method: "POST",
+                                                        url: "",
+                                                        response: {
+                                                            status: 200,
+                                                        },
+                                                    },
+                                                })
+                                            }
+                                        >
+                                            <Plus className="w-3 h-3" />
+                                            Request
+                                        </Button>
+                                    )}
+                                </div>
+                            </div>
+                            {patches.length === 0 && !effect?.mockRequest && (
+                                <span className="text-[9px] text-[var(--text-disabled)] font-mono">
+                                    No effects — transition only updates the marking
+                                </span>
+                            )}
+                            {patches.map((patch, idx) => (
+                                <PatchRow
+                                    key={idx}
+                                    patch={patch}
+                                    onUpdate={(p) => updateEffectPatch(name, idx, p)}
+                                    onRemove={() => removeEffectPatch(name, idx)}
+                                />
+                            ))}
+                            {effect?.mockRequest && (
+                                <MockRequestEditor
+                                    transitionName={name}
+                                    request={effect.mockRequest}
+                                />
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function MockRequestEditor({
+    transitionName,
+    request,
+}: {
+    transitionName: string;
+    request: NonNullable<TransitionEffect["mockRequest"]>;
+}) {
+    const setEffect = useSimulatorStore((s) => s.setEffect);
+    const config = useSimulatorStore((s) => s.config);
+
+    const [bodyDraft, setBodyDraft] = useState(() =>
+        request.body === undefined ? "" : formatJson(request.body)
+    );
+    const [responseDraft, setResponseDraft] = useState(() =>
+        request.response?.body === undefined ? "" : formatJson(request.response.body)
+    );
+    const [bodyError, setBodyError] = useState<string | null>(null);
+    const [responseError, setResponseError] = useState<string | null>(null);
+
+    useEffect(() => {
+        // Only re-sync drafts when the external value differs semantically.
+        // Pressing Enter or typing whitespace inside an in-progress JSON edit
+        // no longer wipes the textarea or jumps the cursor.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setBodyDraft((current) => syncJsonDraft(current, request.body));
+        setResponseDraft((current) => syncJsonDraft(current, request.response?.body));
+    }, [request]);
+
+    const updateRequest = (next: typeof request) => {
+        const existing = config.effects?.[transitionName] ?? {};
+        setEffect(transitionName, { ...existing, mockRequest: next });
+    };
+
+    const removeRequest = () => {
+        const existing = config.effects?.[transitionName];
+        if (!existing) return;
+        const { mockRequest: _, ...rest } = existing;
+        if ((rest.patches?.length ?? 0) === 0 && !rest.description) {
+            setEffect(transitionName, null);
+        } else {
+            setEffect(transitionName, rest);
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-1.5 mt-1 p-2 rounded-[8px] bg-[rgba(255,255,255,0.02)] border border-[var(--glass-border)]">
+            <div className="flex items-center gap-1">
+                <Select
+                    value={request.method}
+                    onChange={(e) =>
+                        updateRequest({
+                            ...request,
+                            method: e.target.value as typeof request.method,
+                        })
+                    }
+                    className="h-7 w-[80px] text-[10px]"
+                >
+                    <SelectItem value="GET">GET</SelectItem>
+                    <SelectItem value="POST">POST</SelectItem>
+                    <SelectItem value="PUT">PUT</SelectItem>
+                    <SelectItem value="PATCH">PATCH</SelectItem>
+                    <SelectItem value="DELETE">DELETE</SelectItem>
+                </Select>
+                <Input
+                    value={request.url}
+                    onChange={(e) => updateRequest({ ...request, url: e.target.value })}
+                    placeholder="/api/path/{{ id }}"
+                    className="h-7 text-[10px] flex-1"
+                />
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-[var(--text-muted)] hover:text-[var(--danger)]"
+                    onClick={removeRequest}
+                >
+                    <Trash2 className="w-3 h-3" />
+                </Button>
+            </div>
+
+            <div className="flex flex-col gap-0.5">
+                <span className="text-[9px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Request body
+                </span>
+                <Textarea
+                    value={bodyDraft}
+                    onChange={(e) => {
+                        setBodyDraft(e.target.value);
+                        const v = e.target.value.trim();
+                        if (v === "") {
+                            setBodyError(null);
+                            updateRequest({ ...request, body: undefined });
+                            return;
+                        }
+                        try {
+                            updateRequest({ ...request, body: JSON.parse(v) });
+                            setBodyError(null);
+                        } catch (err) {
+                            setBodyError(
+                                err instanceof Error ? err.message : "Invalid JSON"
+                            );
+                        }
+                    }}
+                    rows={3}
+                    className="text-[10px]"
+                    spellCheck={false}
+                    placeholder='{"key": "value"}'
+                />
+                {bodyError && (
+                    <span className="text-[9px] text-[var(--danger)] font-mono">
+                        {bodyError}
+                    </span>
+                )}
+            </div>
+
+            <div className="flex items-center gap-1">
+                <span className="text-[9px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Status
+                </span>
+                <Input
+                    type="number"
+                    value={String(request.response?.status ?? 200)}
+                    onChange={(e) =>
+                        updateRequest({
+                            ...request,
+                            response: {
+                                ...(request.response ?? {}),
+                                status: Number(e.target.value) || 200,
+                            },
+                        })
+                    }
+                    className="h-7 w-[80px] text-[10px]"
+                />
+            </div>
+
+            <div className="flex flex-col gap-0.5">
+                <span className="text-[9px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Response body
+                </span>
+                <Textarea
+                    value={responseDraft}
+                    onChange={(e) => {
+                        setResponseDraft(e.target.value);
+                        const v = e.target.value.trim();
+                        if (v === "") {
+                            setResponseError(null);
+                            updateRequest({
+                                ...request,
+                                response: {
+                                    status: request.response?.status ?? 200,
+                                },
+                            });
+                            return;
+                        }
+                        try {
+                            updateRequest({
+                                ...request,
+                                response: {
+                                    status: request.response?.status ?? 200,
+                                    body: JSON.parse(v),
+                                },
+                            });
+                            setResponseError(null);
+                        } catch (err) {
+                            setResponseError(
+                                err instanceof Error ? err.message : "Invalid JSON"
+                            );
+                        }
+                    }}
+                    rows={3}
+                    className="text-[10px]"
+                    spellCheck={false}
+                    placeholder='{"id": "{{ id }}"}'
+                />
+                {responseError && (
+                    <span className="text-[9px] text-[var(--danger)] font-mono">
+                        {responseError}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function PatchRow({
+    patch,
+    onUpdate,
+    onRemove,
+}: {
+    patch: FieldPatch;
+    onUpdate: (patch: Partial<FieldPatch>) => void;
+    onRemove: () => void;
+}) {
+    const [valueDraft, setValueDraft] = useState(() => formatValue(patch.value));
+
+    useEffect(() => {
+        // Re-sync row input when an external value update (template load) lands.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setValueDraft(formatValue(patch.value));
+    }, [patch.value]);
+
+    return (
+        <div className="flex items-center gap-1">
+            <Select
+                value={patch.op ?? "set"}
+                onChange={(e) => onUpdate({ op: e.target.value as FieldPatch["op"] })}
+                className="h-7 w-[70px] text-[10px]"
+            >
+                <SelectItem value="set">set</SelectItem>
+                <SelectItem value="push">push</SelectItem>
+                <SelectItem value="remove">del</SelectItem>
+            </Select>
+            <Input
+                value={patch.path}
+                onChange={(e) => onUpdate({ path: e.target.value })}
+                placeholder="path.to.field"
+                className="h-7 text-[10px] flex-1"
+            />
+            {patch.op !== "remove" && (
+                <Input
+                    value={valueDraft}
+                    onChange={(e) => {
+                        setValueDraft(e.target.value);
+                        onUpdate({ value: parseLiteral(e.target.value) });
+                    }}
+                    placeholder='"value"'
+                    className="h-7 text-[10px] flex-1"
+                />
+            )}
+            <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-[var(--text-muted)] hover:text-[var(--danger)]"
+                onClick={onRemove}
+            >
+                <Trash2 className="w-3 h-3" />
+            </Button>
+        </div>
+    );
+}
+
+function InspectorTab() {
+    const { history, selectedStepIndex, subject, initialSubject } = useSimulatorStore();
+
+    const step = selectedStepIndex !== null ? history[selectedStepIndex] : null;
+
+    if (!step) {
+        return (
+            <div className="flex flex-col gap-2">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Live Subject
+                </span>
+                <pre className="text-[10px] font-mono leading-relaxed text-[var(--text-secondary)] bg-[rgba(255,255,255,0.02)] rounded-[10px] border border-[var(--glass-border)] p-2 overflow-auto max-h-[260px] whitespace-pre-wrap">
+                    {formatJson(history.length === 0 ? initialSubject : subject)}
+                </pre>
+                <span className="text-[9px] text-[var(--text-disabled)] font-mono">
+                    Click a history step to inspect its before/after payload
+                </span>
+            </div>
+        );
+    }
+
+    const changedPaths = new Set(diffPaths(step.subjectBefore, step.subjectAfter));
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Step {(selectedStepIndex ?? 0) + 1} ·{" "}
+                    <span className="text-[var(--accent-bright)]">
+                        {step.transitionName}
+                    </span>
+                </span>
+            </div>
+            {step.effect?.description && (
+                <span className="text-[10px] text-[var(--text-secondary)] italic">
+                    {step.effect.description}
+                </span>
+            )}
+
+            <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                    <span className="text-[9px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                        Before
+                    </span>
+                    <DiffJson value={step.subjectBefore} changedPaths={changedPaths} />
+                </div>
+                <div className="flex flex-col gap-1">
+                    <span className="text-[9px] text-[var(--success)] font-mono uppercase tracking-wider">
+                        After
+                    </span>
+                    <DiffJson
+                        value={step.subjectAfter}
+                        changedPaths={changedPaths}
+                        highlight
+                    />
+                </div>
+            </div>
+
+            {step.resolvedRequest && (
+                <>
+                    <Separator />
+                    <MockRequestView request={step.resolvedRequest} />
+                </>
+            )}
+
+            {step.events.length > 0 && (
+                <>
+                    <Separator />
+                    <div className="flex flex-col gap-1">
+                        <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                            Events Fired
+                        </span>
+                        <div className="flex flex-wrap gap-1">
+                            {step.events.map((evt, i) => (
+                                <Badge
+                                    key={i}
+                                    variant="default"
+                                    className="text-[9px] font-mono bg-[var(--accent-dim)] text-[var(--accent-bright)] border-[var(--accent-border)]"
+                                >
+                                    {evt.type}
+                                </Badge>
+                            ))}
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+function methodColor(method: string): string {
+    switch (method) {
+        case "GET":
+            return "bg-[var(--accent-dim)] text-[var(--accent-bright)] border-[var(--accent-border)]";
+        case "POST":
+            return "bg-[var(--success-dim)] text-[var(--success)] border-[var(--success)]";
+        case "PUT":
+        case "PATCH":
+            return "bg-[var(--warning-dim)] text-[var(--warning)] border-[rgba(251,191,36,0.2)]";
+        case "DELETE":
+            return "bg-[rgba(248,113,113,0.1)] text-[var(--danger)] border-[rgba(248,113,113,0.2)]";
+        default:
+            return "bg-[var(--glass-base)] text-[var(--text-secondary)] border-[var(--glass-border)]";
+    }
+}
+
+function statusColor(status: number): string {
+    if (status >= 200 && status < 300)
+        return "text-[var(--success)] border-[var(--success)] bg-[var(--success-dim)]";
+    if (status >= 400)
+        return "text-[var(--danger)] border-[rgba(248,113,113,0.2)] bg-[rgba(248,113,113,0.1)]";
+    return "text-[var(--warning)] border-[rgba(251,191,36,0.2)] bg-[var(--warning-dim)]";
+}
+
+function MockRequestView({
+    request,
+}: {
+    request: NonNullable<SimulationStep["resolvedRequest"]>;
+}) {
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1">
+                <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                    Mock Request
+                </span>
+                <div className="flex items-center gap-1.5 flex-wrap">
+                    <Badge
+                        variant="default"
+                        className={`text-[9px] font-mono ${methodColor(request.method)}`}
+                    >
+                        {request.method}
+                    </Badge>
+                    <span className="text-[10px] font-mono text-[var(--text-secondary)] truncate flex-1 min-w-0">
+                        {request.url || "—"}
+                    </span>
+                </div>
+                {request.body !== undefined && (
+                    <pre className="text-[10px] font-mono leading-relaxed text-[var(--text-secondary)] bg-[rgba(255,255,255,0.02)] rounded-[10px] border border-[var(--glass-border)] p-2 overflow-auto max-h-[120px] whitespace-pre-wrap">
+                        {formatJson(request.body)}
+                    </pre>
+                )}
+            </div>
+
+            {request.response && (
+                <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-1.5">
+                        <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                            Mock Response
+                        </span>
+                        <Badge
+                            variant="default"
+                            className={`text-[9px] font-mono ${statusColor(request.response.status)}`}
+                        >
+                            {request.response.status}
+                        </Badge>
+                    </div>
+                    {request.response.body !== undefined && (
+                        <pre className="text-[10px] font-mono leading-relaxed text-[var(--text-secondary)] bg-[rgba(255,255,255,0.02)] rounded-[10px] border border-[var(--glass-border)] p-2 overflow-auto max-h-[120px] whitespace-pre-wrap">
+                            {formatJson(request.response.body)}
+                        </pre>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function DiffJson({
+    value,
+    changedPaths,
+    highlight = false,
+}: {
+    value: Record<string, JsonValue>;
+    changedPaths: Set<string>;
+    highlight?: boolean;
+}) {
+    return (
+        <pre className="text-[10px] font-mono leading-relaxed bg-[rgba(255,255,255,0.02)] rounded-[10px] border border-[var(--glass-border)] p-2 overflow-auto max-h-[180px] whitespace-pre-wrap break-all">
+            {Object.entries(value).map(([k, v]) => {
+                const isChanged = [...changedPaths].some(
+                    (p) => p === k || p.startsWith(`${k}.`)
+                );
+                return (
+                    <div
+                        key={k}
+                        className={
+                            isChanged
+                                ? highlight
+                                    ? "text-[var(--success)] break-all"
+                                    : "text-[var(--warning)] break-all"
+                                : "text-[var(--text-secondary)] break-all"
+                        }
+                    >
+                        <span className="text-[var(--text-muted)]">{k}:</span>{" "}
+                        {JSON.stringify(v)}
+                    </div>
+                );
+            })}
+        </pre>
+    );
+}
+
+export function SimulatorPanel() {
+    const {
+        active,
+        tab,
+        history,
         autoPlaying,
         autoPlaySpeed,
         applyTransition,
@@ -25,13 +1047,12 @@ export function SimulatorPanel() {
         deactivate,
         toggleAutoPlay,
         setAutoPlaySpeed,
-        toggleGuard,
-        engine,
+        setTab,
+        enabledTransitions,
     } = useSimulatorStore();
 
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    // Auto-play logic
     const autoStep = useCallback(() => {
         const enabled = useSimulatorStore.getState().enabledTransitions;
         if (enabled.length === 0) {
@@ -44,6 +1065,9 @@ export function SimulatorPanel() {
 
     useEffect(() => {
         if (autoPlaying) {
+            // Fire one step immediately so the user gets feedback without
+            // waiting for the first interval tick.
+            autoStep();
             intervalRef.current = setInterval(autoStep, autoPlaySpeed);
         } else if (intervalRef.current) {
             clearInterval(intervalRef.current);
@@ -56,20 +1080,10 @@ export function SimulatorPanel() {
 
     if (!active) return null;
 
-    const activePlaces = Object.entries(marking)
-        .filter(([, count]) => count > 0)
-        .map(([name, count]) => ({ name, count }));
-
     const isDeadEnd = enabledTransitions.length === 0;
 
-    // Get transitions that have guards
-    const guardedTransitions = engine
-        ? engine.getDefinition().transitions.filter((t) => t.guard)
-        : [];
-
     return (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 w-[480px] max-h-[440px] bg-[#12121f] border border-[var(--glass-border)] rounded-[18px] flex flex-col shadow-[0_8px_32px_rgba(0,0,0,0.4)] overflow-hidden">
-            {/* Header */}
+        <div className="absolute top-16 right-4 bottom-4 z-20 w-[440px] bg-[#12121f] border border-[var(--glass-border)] rounded-[18px] flex flex-col shadow-[0_8px_32px_rgba(0,0,0,0.4)] overflow-hidden">
             <div className="flex items-center justify-between px-4 py-2.5 border-b border-[var(--glass-border)]">
                 <div className="flex items-center gap-2">
                     <Play className="w-3.5 h-3.5 text-[var(--success)]" />
@@ -84,238 +1098,66 @@ export function SimulatorPanel() {
                     </Badge>
                 </div>
                 <div className="flex items-center gap-1">
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6"
-                        onClick={reset}
-                    >
-                        <RotateCcw className="w-3 h-3" />
-                    </Button>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6"
-                        onClick={deactivate}
-                    >
-                        <X className="w-3 h-3" />
-                    </Button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6"
+                                onClick={reset}
+                                disabled={history.length === 0}
+                            >
+                                <RotateCcw className="w-3 h-3" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                            Restart from initial state
+                        </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6"
+                                onClick={deactivate}
+                            >
+                                <X className="w-3 h-3" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Close simulator</TooltipContent>
+                    </Tooltip>
                 </div>
             </div>
 
-            <div className="flex-1 overflow-auto p-4 flex flex-col gap-3">
-                {/* Current marking */}
-                <div className="flex flex-col gap-1.5">
-                    <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
-                        Current State
-                    </span>
-                    <div className="flex flex-wrap gap-1.5">
-                        {activePlaces.map(({ name, count }) => {
-                            const pa = analysis?.places[name];
-                            const hasXorSplit = pa?.patterns.includes("xor-split");
-                            const hasOrSplit = pa?.patterns.includes("or-split");
-                            const hasXorJoin = pa?.patterns.includes("xor-join");
-                            const hasOrJoin = pa?.patterns.includes("or-join");
-                            const patternHint = hasXorSplit
-                                ? "XOR"
-                                : hasOrSplit
-                                  ? "OR"
-                                  : hasXorJoin
-                                    ? "XOR-JOIN"
-                                    : hasOrJoin
-                                      ? "MERGE"
-                                      : null;
-                            return (
-                                <Badge
-                                    key={name}
-                                    variant="default"
-                                    className="text-[11px] font-mono bg-[var(--success-dim)] text-[var(--success)] border-[var(--success)] gap-1"
-                                >
-                                    {name}
-                                    {count > 1 && ` ×${count}`}
-                                    {patternHint && (
-                                        <span className="text-[8px] px-1 py-px rounded bg-[var(--warning-dim)] text-[var(--warning)] border border-[rgba(251,191,36,0.2)]">
-                                            {patternHint}
-                                        </span>
-                                    )}
-                                </Badge>
-                            );
-                        })}
-                        {activePlaces.length === 0 && (
-                            <span className="text-[11px] text-[var(--text-disabled)] font-mono">
-                                no active places
-                            </span>
-                        )}
-                    </div>
-                </div>
-
-                {/* Guards */}
-                {guardedTransitions.length > 0 && (
-                    <>
-                        <Separator />
-                        <div className="flex flex-col gap-1.5">
-                            <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
-                                Guards
-                            </span>
-                            <div className="flex flex-col gap-1">
-                                {guardedTransitions.map((t) => {
-                                    const isBlocked = blockedGuards[t.name];
-                                    return (
-                                        <div
-                                            key={t.name}
-                                            className="flex items-center gap-2 text-[10px] font-mono"
-                                        >
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className={`h-5 w-5 ${isBlocked ? "text-[var(--danger)]" : "text-[var(--success)]"}`}
-                                                        onClick={() =>
-                                                            toggleGuard(t.name)
-                                                        }
-                                                    >
-                                                        {isBlocked ? (
-                                                            <ShieldOff className="w-3 h-3" />
-                                                        ) : (
-                                                            <Shield className="w-3 h-3" />
-                                                        )}
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent side="right">
-                                                    {isBlocked
-                                                        ? "Guard is blocked — click to allow"
-                                                        : "Guard passes — click to block"}
-                                                </TooltipContent>
-                                            </Tooltip>
-                                            <span
-                                                className={
-                                                    isBlocked
-                                                        ? "text-[var(--danger)] line-through"
-                                                        : "text-[var(--text-secondary)]"
-                                                }
-                                            >
-                                                {t.name}
-                                            </span>
-                                            <span className="text-[var(--text-muted)] truncate max-w-[200px]">
-                                                {t.guard}
-                                            </span>
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        </div>
-                    </>
-                )}
-
-                <Separator />
-
-                {/* Available transitions */}
-                <div className="flex flex-col gap-1.5">
-                    <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
-                        Available Transitions
-                    </span>
-                    {isDeadEnd ? (
-                        <span className="text-[11px] text-[var(--warning)] font-mono">
-                            Dead end — no transitions available
-                        </span>
-                    ) : (
-                        <div className="flex flex-wrap gap-1.5">
-                            {enabledTransitions.map((t) => {
-                                const ta = analysis?.transitions[t.name];
-                                const patternLabel =
-                                    ta?.pattern === "and-join"
-                                        ? "AND"
-                                        : ta?.pattern === "and-split"
-                                          ? "FORK"
-                                          : ta?.pattern === "and-split-join"
-                                            ? "AND+FORK"
-                                            : null;
-                                return (
-                                    <Button
-                                        key={t.name}
-                                        variant="ghost"
-                                        size="sm"
-                                        className="h-7 text-[11px] font-mono border border-[var(--success-dim)] text-[var(--success)] hover:bg-[var(--success-dim)] gap-1"
-                                        onClick={() => applyTransition(t.name)}
-                                        disabled={autoPlaying}
-                                    >
-                                        {t.name}
-                                        {patternLabel && (
-                                            <span className="text-[8px] px-1 py-px rounded bg-[var(--accent-dim)] text-[var(--accent-bright)] border border-[var(--accent-border)]">
-                                                {patternLabel}
-                                            </span>
-                                        )}
-                                    </Button>
-                                );
-                            })}
-                        </div>
-                    )}
-                </div>
-
-                {/* History */}
-                {history.length > 0 && (
-                    <>
-                        <Separator />
-                        <div className="flex flex-col gap-1">
-                            <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
-                                History
-                            </span>
-                            <div className="flex flex-col gap-0.5 max-h-[100px] overflow-auto">
-                                {[...history].reverse().map((step, i) => {
-                                    const fromPlaces = Object.entries(step.fromMarking)
-                                        .filter(([, c]) => c > 0)
-                                        .map(([n]) => n);
-                                    const toPlaces = Object.entries(step.toMarking)
-                                        .filter(([, c]) => c > 0)
-                                        .map(([n]) => n);
-                                    return (
-                                        <div
-                                            key={history.length - i}
-                                            className="text-[10px] font-mono text-[var(--text-secondary)] flex items-center gap-1"
-                                        >
-                                            <span className="text-[var(--text-muted)] w-4 text-right shrink-0">
-                                                {history.length - i}.
-                                            </span>
-                                            <span className="text-[var(--accent-bright)]">
-                                                {step.transitionName}
-                                            </span>
-                                            <span className="text-[var(--text-muted)]">
-                                                :
-                                            </span>
-                                            <span>{fromPlaces.join(", ")}</span>
-                                            <span className="text-[var(--text-muted)]">
-                                                →
-                                            </span>
-                                            <span>{toPlaces.join(", ")}</span>
-                                            {step.events.length > 0 && (
-                                                <Tooltip>
-                                                    <TooltipTrigger asChild>
-                                                        <span className="text-[8px] px-1 py-px rounded bg-[var(--accent-dim)] text-[var(--accent-bright)] border border-[var(--accent-border)] cursor-help">
-                                                            {step.events.length} events
-                                                        </span>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent side="left">
-                                                        <div className="flex flex-col gap-0.5 text-[9px]">
-                                                            {step.events.map((evt, j) => (
-                                                                <span key={j}>
-                                                                    {evt.type}
-                                                                </span>
-                                                            ))}
-                                                        </div>
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                            )}
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        </div>
-                    </>
-                )}
+            <div className="flex border-b border-[var(--glass-border)]">
+                <TabButton
+                    icon={ListChecks}
+                    label="Steps"
+                    active={tab === "steps"}
+                    onClick={() => setTab("steps")}
+                    badge={history.length}
+                />
+                <TabButton
+                    icon={FileText}
+                    label="Scenario"
+                    active={tab === "scenario"}
+                    onClick={() => setTab("scenario")}
+                />
+                <TabButton
+                    icon={SearchCode}
+                    label="Inspector"
+                    active={tab === "inspector"}
+                    onClick={() => setTab("inspector")}
+                />
             </div>
 
-            {/* Footer controls */}
+            <div className="flex-1 overflow-auto p-4">
+                {tab === "steps" && <StepsTab />}
+                {tab === "scenario" && <ScenarioTab />}
+                {tab === "inspector" && <InspectorTab />}
+            </div>
+
             <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--glass-border)]">
                 <Button
                     variant="ghost"
@@ -326,6 +1168,17 @@ export function SimulatorPanel() {
                 >
                     <SkipBack className="w-3 h-3" />
                     Step Back
+                </Button>
+
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-[10px] gap-1"
+                    onClick={reset}
+                    disabled={history.length === 0}
+                >
+                    <RotateCcw className="w-3 h-3" />
+                    Restart
                 </Button>
 
                 <div className="flex-1" />

--- a/components/feedback-fab.tsx
+++ b/components/feedback-fab.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import { useSimulatorStore } from "@/stores/simulator";
 
 const FEEDBACK_TYPES = [
     { value: "bug", label: "Bug", icon: Bug, color: "var(--danger)" },
@@ -47,6 +48,9 @@ const MAX_IMAGE_SIZE = 2 * 1024 * 1024; // 2MB
 
 export function FeedbackFab() {
     const [open, setOpen] = useState(false);
+    // Right side is occupied by the simulator sheet during play —
+    // dock the FAB on the left then to avoid overlap.
+    const simActive = useSimulatorStore((s) => s.active);
     const [type, setType] = useState<FeedbackType>("general");
     const [message, setMessage] = useState("");
     const [name, setName] = useState("");
@@ -132,7 +136,7 @@ export function FeedbackFab() {
             {/* FAB Button */}
             <motion.button
                 onClick={() => setOpen(!open)}
-                className="fixed bottom-6 right-6 z-50 w-12 h-12 rounded-full bg-linear-to-br from-[#7c6ff7] to-[#9d94ff] text-white shadow-[0_4px_24px_var(--accent-glow)] hover:shadow-[0_4px_32px_var(--accent-glow)] transition-shadow flex items-center justify-center cursor-pointer"
+                className={`fixed bottom-6 z-50 w-12 h-12 rounded-full bg-linear-to-br from-[#7c6ff7] to-[#9d94ff] text-white shadow-[0_4px_24px_var(--accent-glow)] hover:shadow-[0_4px_32px_var(--accent-glow)] transition-all flex items-center justify-center cursor-pointer ${simActive ? "left-6" : "right-6"}`}
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
             >
@@ -169,7 +173,7 @@ export function FeedbackFab() {
                         animate={{ opacity: 1, y: 0, scale: 1 }}
                         exit={{ opacity: 0, y: 20, scale: 0.95 }}
                         transition={{ duration: 0.2 }}
-                        className="fixed bottom-20 right-6 z-50 w-[340px] rounded-[18px] shadow-[0_16px_64px_rgba(0,0,0,0.5)] flex flex-col overflow-hidden max-h-[calc(100vh-120px)] border border-[var(--glass-border-strong)]"
+                        className={`fixed bottom-20 z-50 w-[340px] rounded-[18px] shadow-[0_16px_64px_rgba(0,0,0,0.5)] flex flex-col overflow-hidden max-h-[calc(100vh-120px)] border border-[var(--glass-border-strong)] ${simActive ? "left-6" : "right-6"}`}
                         style={{
                             background:
                                 "linear-gradient(135deg, rgba(20, 20, 42, 0.92), rgba(12, 12, 28, 0.95))",

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+    ({ className, ...props }, ref) => {
+        return (
+            <textarea
+                className={cn(
+                    "flex w-full rounded-[10px] px-3 py-2 text-xs font-mono leading-relaxed resize-y",
+                    "bg-[var(--glass-base)] border border-[var(--glass-border)]",
+                    "text-[var(--text-primary)] placeholder:text-[var(--text-muted)]",
+                    "transition-colors duration-150",
+                    "hover:border-[var(--glass-border-hover)]",
+                    "focus-visible:outline-none focus-visible:border-[var(--accent-bright)]",
+                    "disabled:cursor-not-allowed disabled:opacity-40",
+                    className
+                )}
+                ref={ref}
+                {...props}
+            />
+        );
+    }
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/hooks/use-autosave.ts
+++ b/hooks/use-autosave.ts
@@ -18,7 +18,7 @@ export function useAutosave({
     onLocalSave,
 }: UseAutosaveOptions = {}) {
     const [status, setStatus] = useState<SaveStatus>("idle");
-    const { nodes, edges, workflowMeta } = useEditorStore();
+    const { nodes, edges, workflowMeta, simulationConfig } = useEditorStore();
     const prevRef = useRef<string>("");
 
     const saveToCloud = useCallback(async () => {
@@ -34,6 +34,7 @@ export function useAutosave({
                     symfonyVersion: workflowMeta.symfonyVersion,
                     type: workflowMeta.type,
                     graphJson: { nodes, edges, meta: workflowMeta },
+                    simulationConfig: simulationConfig ?? null,
                 }),
             });
 
@@ -43,7 +44,7 @@ export function useAutosave({
         } catch {
             setStatus("error");
         }
-    }, [workflowId, nodes, edges, workflowMeta]);
+    }, [workflowId, nodes, edges, workflowMeta, simulationConfig]);
 
     const debouncedSave = useDebouncedCallback(() => {
         if (workflowId) {
@@ -58,7 +59,12 @@ export function useAutosave({
     useEffect(() => {
         if (!enabled) return;
 
-        const snapshot = JSON.stringify({ nodes, edges, workflowMeta });
+        const snapshot = JSON.stringify({
+            nodes,
+            edges,
+            workflowMeta,
+            simulationConfig,
+        });
         if (snapshot === prevRef.current) return;
         prevRef.current = snapshot;
 
@@ -69,7 +75,7 @@ export function useAutosave({
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setStatus("saving");
         debouncedSave();
-    }, [nodes, edges, workflowMeta, enabled, debouncedSave]);
+    }, [nodes, edges, workflowMeta, simulationConfig, enabled, debouncedSave]);
 
     return { status, saveToCloud };
 }

--- a/lib/data/blog-posts.ts
+++ b/lib/data/blog-posts.ts
@@ -9,6 +9,385 @@ export interface BlogPost {
 
 export const blogPosts: BlogPost[] = [
     {
+        slug: "walkthrough-publishing-an-article-scenario",
+        title: "Walkthrough: Building the 'Publishing an Article' Scenario from Scratch",
+        date: "2026-04-30",
+        excerpt:
+            "A step-by-step walkthrough of designing a playable workflow scenario in SymFlowBuilder — from drawing places and transitions, to writing patches, to attaching mock API calls, to embedding the result in your docs.",
+        tags: ["tutorial", "simulator", "scenarios", "article", "walkthrough"],
+        content: `## What we are building
+
+A blog post going through editorial review. Five places — \`draft\`, \`pending_review\`, \`approved\`, \`rejected\`, \`published\` — and four transitions. By the end you will be able to click through the simulator and watch an article object evolve from a draft with no reviewer to a published post with a public URL, with the API calls a real backend would make plotted out beside it.
+
+This is the workflow shipped as the **Publishing an article** template. We are going to rebuild it from scratch, slowly, so each piece earns its place.
+
+## Step 1 — Draw the graph
+
+Open the [editor](/editor) and drag five state nodes onto the canvas. Name them:
+
+- \`draft\` — initial state
+- \`pending_review\`
+- \`approved\`
+- \`rejected\`
+- \`published\`
+
+Mark \`draft\` as the initial state in the properties panel. This becomes \`initial_marking: draft\` in the exported YAML.
+
+Now connect them with four transitions:
+
+- \`submit_for_review\` — \`draft\` → \`pending_review\`
+- \`approve\` — \`pending_review\` → \`approved\`
+- \`reject\` — \`pending_review\` → \`rejected\`
+- \`publish\` — \`approved\` → \`published\`
+
+Set the workflow type to \`state_machine\` (the article is in exactly one place at a time) and set \`property: status\` on the marking store — that is the field name on your domain object that holds the current state.
+
+At this point you have a working state machine. Click **Simulate** in the toolbar and you can already step through it. But every transition does the same thing: shift a token between abstract place names. That is not very interesting yet.
+
+## Step 2 — Open the Scenario tab
+
+The simulator sheet on the right has three tabs: **Steps**, **Scenario**, **Inspector**. Switch to **Scenario**.
+
+This is where the article lives. The starting **subject** — the JSON object your workflow operates on — needs to describe what an article actually looks like in your system. Paste this in:
+
+\`\`\`json
+{
+    "id": "art_1042",
+    "title": "My first post",
+    "body": "Hello, world.",
+    "author": "alice",
+    "reviewer": null,
+    "reviewNotes": null,
+    "publishedAt": null
+}
+\`\`\`
+
+Notice there is no \`status\` field. You do not need one — because you set \`property: status\` on the workflow, the simulator automatically writes the current marking into \`subject.status\` after every step. State machines write a single string (\`"draft"\`); workflow-type Petri nets write an array of place names. This mirrors what Symfony's marking store does in production.
+
+So at \`t=0\`, your live subject is actually:
+
+\`\`\`json
+{
+    "id": "art_1042",
+    "title": "My first post",
+    "body": "Hello, world.",
+    "author": "alice",
+    "reviewer": null,
+    "reviewNotes": null,
+    "publishedAt": null,
+    "status": "draft"
+}
+\`\`\`
+
+That is what shows up in the Inspector.
+
+## Step 3 — Write the patches
+
+Below the subject editor is a card per transition. Each card has a **+ Patch** button and a **+ Request** button. Patches mutate the subject when the transition fires.
+
+A patch has three pieces: an **op**, a **path**, and a **value**.
+
+The op is one of three things:
+
+- **set** — assign a value at the path. Replaces whatever was there. *You will use this almost every time.* Example: \`set reviewer = "bob"\` becomes \`subject.reviewer = "bob"\`.
+- **push** — append to an array at the path. Creates the array if missing. Example: \`push history "submitted"\` becomes \`subject.history.push("submitted")\`.
+- **del** — delete the field entirely. Example: \`del reviewer\` becomes \`delete subject.reviewer\`. Different from \`set reviewer = null\` — \`del\` removes the key from the object.
+
+The path is a JSON-pointer-style string: \`field\`, \`nested.field\`, or \`items[0].name\` for arrays. The value is anything JSON. Strings, numbers, booleans, arrays, nested objects.
+
+Now configure the four transitions:
+
+### \`submit_for_review\`
+
+The author submits the draft. A reviewer gets assigned.
+
+\`\`\`text
++ Patch  set  reviewer  "bob"
+\`\`\`
+
+### \`approve\`
+
+The reviewer signs off.
+
+\`\`\`text
++ Patch  set  reviewNotes  "LGTM"
+\`\`\`
+
+### \`reject\`
+
+The reviewer asks for changes. Notes get set, reviewer gets cleared so a new one can be assigned next round.
+
+\`\`\`text
++ Patch  set  reviewNotes  "Needs rework"
++ Patch  set  reviewer     null
+\`\`\`
+
+(You could use \`del reviewer\` instead — same end-result if you do not care about the field existing.)
+
+### \`publish\`
+
+The article goes live. We stamp a publish timestamp.
+
+\`\`\`text
++ Patch  set  publishedAt  "2026-04-30T10:00:00.000Z"
+\`\`\`
+
+## Step 4 — Walk through it
+
+Switch back to **Steps**. Click \`submit_for_review\`. Two things happen:
+
+1. The marking advances from \`draft\` to \`pending_review\`. The state node on the canvas glows green; the previous one dims.
+2. The subject mutates: \`reviewer\` becomes \`"bob"\` and \`status\` becomes \`"pending_review"\`.
+
+You can see the second part directly: open **Inspector** and you get a side-by-side diff of the subject before and after that step. Changed fields are highlighted. \`reviewer\` flips from \`null\` to \`"bob"\`. \`status\` flips from \`"draft"\` to \`"pending_review"\`.
+
+Click \`approve\`, then \`publish\`. The article walks the happy path. If you go back and pick \`reject\` instead, you can watch the alternate branch play out — \`reviewNotes\` gets set to \`"Needs rework"\`, \`reviewer\` clears to \`null\`, the article ends up in \`rejected\`.
+
+This is the moment scenarios stop being abstract. You are not reading a YAML file. You are watching an article move through a process.
+
+## Step 5 — Add mock API calls
+
+Most workflows are not just state machines — each transition typically corresponds to a real API call. \`submit_for_review\` posts to \`/api/articles/.../submit\`. \`publish\` posts to \`/api/articles/.../publish\`. Real listeners fire those requests in production.
+
+In the simulator you can attach a *mock* request to each transition — a fake HTTP call that the Inspector will display as if it had fired. No real network goes out. It is a teaching surface, not a backend mock.
+
+Click **+ Request** on the \`submit_for_review\` card. The editor expands inline:
+
+- **Method**: \`POST\`
+- **URL**: \`/api/articles/{{id}}/submit\`
+- **Request body**:
+  \`\`\`json
+  { "reviewer": "bob" }
+  \`\`\`
+- **Status**: \`202\`
+- **Response body**:
+  \`\`\`json
+  { "id": "{{id}}", "status": "pending_review" }
+  \`\`\`
+
+Notice the \`{{id}}\` interpolation. The simulator substitutes \`{{ subject.path }}\` references with the actual subject value at the moment the transition fires. So when you click \`submit_for_review\`, the Inspector shows \`POST /api/articles/art_1042/submit\` — the \`{{id}}\` gets resolved against the live subject. Substitution works in URLs and in JSON values.
+
+Add similar requests for the other three transitions:
+
+- \`approve\` → \`POST /api/articles/{{id}}/approve\` returning \`200 { "id": "{{id}}", "status": "approved" }\`
+- \`reject\` → \`POST /api/articles/{{id}}/reject\` returning \`200 { "id": "{{id}}", "status": "rejected" }\`
+- \`publish\` → \`POST /api/articles/{{id}}/publish\` returning \`200 { "id": "{{id}}", "status": "published", "url": "https://example.com/blog/{{id}}" }\`
+
+Now walk the scenario again. Click any step in the history. The Inspector shows the subject diff *and* the resolved mock request — method, URL, body, status, response. The substituted values are frozen into the step's history at the moment of the transition; if you patch \`id\` later, the historical request keeps the value it had at the time.
+
+## Step 6 — Save and share
+
+When you stop the simulator (or it auto-saves), the scenario gets persisted to the workflow alongside the graph. Reload the page and the scenario comes back. Sign in and the scenario rides up to the cloud with the workflow.
+
+Open the share dialog and make the workflow public. Anyone visiting \`/w/[shareId]\` can hit **Simulate** and walk through your scenario without signing in. They get the article-publishing experience exactly as you designed it.
+
+For docs sites, add an iframe:
+
+\`\`\`html
+<iframe
+  src="https://symflowbuilder.com/embed/<shareId>?play=1&minimap=0&branding=0"
+  width="100%"
+  height="560"
+  style="border:0;border-radius:14px"
+  loading="lazy"
+  title="Publishing an article"
+></iframe>
+\`\`\`
+
+The \`?play=1\` query param makes the embed start the simulator automatically — readers land on a runnable demo, not a static diagram.
+
+## What is actually persisting
+
+Under the hood, your scenario is a small JSON blob saved on the workflow:
+
+\`\`\`json
+{
+    "subject": {
+        "id": "art_1042",
+        "title": "My first post",
+        "...": "..."
+    },
+    "effects": {
+        "submit_for_review": {
+            "patches": [{ "op": "set", "path": "reviewer", "value": "bob" }],
+            "mockRequest": {
+                "method": "POST",
+                "url": "/api/articles/{{id}}/submit",
+                "body": { "reviewer": "bob" },
+                "response": { "status": 202, "body": { "id": "{{id}}", "status": "pending_review" } }
+            }
+        },
+        "approve": { "...": "..." },
+        "reject":  { "...": "..." },
+        "publish": { "...": "..." }
+    }
+}
+\`\`\`
+
+It lives in a separate \`simulationConfig\` column on the workflow row in PostgreSQL. **Crucially, it never enters the Symfony YAML export.** Your exported \`config/packages/workflow.yaml\` stays a clean Symfony workflow definition — places, transitions, guards, metadata. The scenario is a layer on top, scoped to the simulator.
+
+That separation is intentional. Scenarios are for explaining a workflow to a teammate or stakeholder; the YAML is for running it in production. Different audiences, different artifacts.
+
+## Why this is worth your time
+
+Half of every workflow review I have ever sat in starts with someone drawing on a whiteboard while saying "okay so an article comes in..." and then mutating a fictional object verbally. Scenarios put that conversation into the tool. Your reviewer no longer needs to imagine the article — they can click through the actual state machine with real-looking data and see, at each step, what the article looks like and what API the system would call.
+
+Hand someone a workflow link and they will read the diagram. Hand them a workflow link with a scenario and they will *use* it. That is the difference.
+
+## Try it now
+
+The full template is one click away if you do not want to build it from scratch:
+
+1. Open the [editor](/editor)
+2. Drag five places and four transitions matching the layout above
+3. Click **Simulate**, switch to **Scenario**, click **Publishing an article**
+4. Walk it through
+
+Or fork the existing public scenario and modify it — change the reviewer to your own team's names, swap the URL prefix to your real backend, add a \`tags\` array and \`push\` to it on each transition. The whole point of scenarios is that the data fits *your* domain, not ours.`,
+    },
+    {
+        slug: "playable-scenarios-mock-data-in-the-simulator",
+        title: "Playable Scenarios: Walk Through a Workflow Like You're Publishing an Article",
+        date: "2026-04-30",
+        excerpt:
+            "The simulator now carries a real subject — an article, an order, a document — through your workflow. Each transition can mutate the subject and show a mock API request. Click through it like an n8n run.",
+        tags: ["feature", "simulator", "scenarios", "mock-http"],
+        content: `## A simulator that only knew states was only half a simulator
+
+The original SymFlowBuilder simulator could fire transitions, track active places, evaluate guards, and replay Symfony events. What it could *not* do was answer the most common question someone asks of a workflow diagram:
+
+> "But what does the data look like at each step?"
+
+A workflow is rarely just a graph. It is a graph plus a *thing* moving through it — an article on its way to publication, an order on its way to fulfillment, a moderation case waiting on a reviewer. Without that thing, the simulator was an abstract token-pusher. You could see that \`approved\` was reachable from \`submitted\`. You could not see what an *approved article* actually looked like.
+
+This release fixes that. The simulator now carries a **subject** — the JSON object your workflow operates on — and lets each transition mutate it as it fires. You can also attach a fake HTTP request to any transition and see exactly what would have hit your backend. The result feels less like watching a state machine and more like clicking through an n8n run.
+
+## The article-publishing example, end to end
+
+Open the editor, build a state machine with five places — \`draft\`, \`pending_review\`, \`approved\`, \`rejected\`, \`published\` — and four transitions: \`submit_for_review\`, \`approve\`, \`reject\`, \`publish\`. Click **Simulate**.
+
+The simulator panel now has three tabs: **Steps**, **Scenario**, and **Inspector**. Open **Scenario** and click the **Publishing an article** template card.
+
+The starting subject lands on the page:
+
+\`\`\`json
+{
+    "id": "art_1042",
+    "title": "My first post",
+    "body": "Hello, world.",
+    "author": "alice",
+    "reviewer": null,
+    "reviewNotes": null,
+    "publishedAt": null
+}
+\`\`\`
+
+Below it, four transition cards. Each one has patches that mutate the subject and a mock HTTP request that *would* have fired:
+
+\`\`\`text
+submit_for_review
+  patches:  set reviewer = "bob"
+  request:  POST /api/articles/{{id}}/submit
+            { "reviewer": "bob" }
+            → 202 { "id": "{{id}}", "status": "pending_review" }
+\`\`\`
+
+Switch to **Steps**. Click \`submit_for_review\`. The article is now in \`pending_review\` and the reviewer is bob. Click \`approve\`. Then \`publish\`. The history list shows each step with a colored \`POST\` badge — visual proof that a request would have fired.
+
+Click any history row. The panel jumps to **Inspector** and shows you, side by side, what the article looked like *before* and *after* that transition, with the changed fields highlighted. Below that: the resolved mock request — \`POST /api/articles/art_1042/publish\` (the \`{{id}}\` was substituted with the real subject value at the moment of the transition) and a \`200\` response with a real-looking publish URL.
+
+That is the moment the feature clicks. You are not reading a YAML file or staring at boxes connected by arrows. You are watching an article get reviewed and published, with the API calls a real backend would make plotted out next to it.
+
+## What you can declare per transition
+
+Each transition can carry an optional **effect** with three pieces, all of them optional:
+
+### 1. A description
+
+A one-line note about what the transition represents. Shown in the Inspector at the top of the step.
+
+### 2. Patches that mutate the subject
+
+A list of \`{ op, path, value }\` operations applied to a deep-cloned subject when the transition fires. Three ops are supported:
+
+- \`set\` — write a value at the path. Path syntax is \`field.nested.deeper\` or \`items[0].name\`.
+- \`push\` — append a value to an array at the path.
+- \`remove\` — delete a key or splice an array element.
+
+Patches are interpreted client-side, in pure JavaScript, on a *cloned* subject. Nothing escapes the simulator. The original subject in the scenario is your "starting state" — re-running the simulator always rewinds to it.
+
+### 3. A mock HTTP request
+
+A pretend request the transition would have fired, with method, URL, optional body, and an optional canned response with status + body. URLs and JSON values support \`{{ subject.path }}\` interpolation, so:
+
+\`\`\`text
+POST /api/articles/{{id}}/publish
+\`\`\`
+
+…becomes \`POST /api/articles/art_1042/publish\` when fired. The substitution happens once, at the moment of the transition, using the subject *as it was* before the patches ran. That snapshot is frozen into the step's history — even if you patch \`id\` later, the historical request keeps the value it had at the time.
+
+No actual network call is made. The mock request is a UI artifact. That is intentional: scenarios are for *teaching, reviewing, and demoing* a workflow, not for testing your backend.
+
+## Three tabs, one mental model
+
+- **Steps** is the playback surface. Active places, available transitions, history. Click history to jump to Inspector.
+- **Scenario** is the design surface. Subject editor, per-transition patches and mock requests, template gallery. Edits persist with the workflow when you save.
+- **Inspector** is the *what just happened* surface. Before/after subject diff for the selected step, with changed paths highlighted, plus the resolved mock request and response.
+
+The footer carries the playback controls — **Step Back**, **Restart**, **Auto-play** with a configurable interval, and a stop. The header has tooltipped icons for restart and close.
+
+## Persistence and sharing
+
+A scenario is stored alongside the workflow in a new \`simulationConfig\` JSONB column. It travels with the workflow:
+
+- Auto-save picks up scenario edits and writes them to the cloud (signed-in users) or localStorage (guests), debounced 2 seconds.
+- The public share view at \`/w/[shareId]\` loads the scenario when the share owner has saved one. Anyone visiting the link can hit **Simulate** and walk the article through the workflow without an account.
+- The iframe embed at \`/embed/[shareId]\` is now interactive. Drop a \`<iframe>\` into a docs page, add \`?play=1\`, and the scenario auto-starts. Readers click through it the same way they click through an n8n demo on the n8n website.
+
+\`\`\`html
+<iframe
+  src="https://symflowbuilder.com/embed/abc123?play=1&minimap=0&branding=0"
+  width="100%"
+  height="560"
+  style="border:0;border-radius:14px"
+  loading="lazy"
+  title="Article publishing flow"
+></iframe>
+\`\`\`
+
+That iframe is a runnable demo of your workflow. Embed it in your README, your docs site, your design review document — wherever explaining the flow has so far required either a screenshot or an awkward "let me share my screen" moment.
+
+## What this is *not*
+
+A few deliberate non-goals, since people will ask:
+
+- **Not a backend mock**. No request leaves the browser. Mock responses are static — no scripting, no JavaScript evaluation. If you need a real mock backend, [MSW](https://mswjs.io) is what you want; this is a teaching surface.
+- **Not in the Symfony YAML export**. Scenarios are simulator-only and live in their own column. Your exported YAML stays a clean Symfony workflow definition that drops into \`config/packages/workflow.yaml\` without surprises.
+- **Not a replacement for tests**. It is excellent for *showing* a flow. It is not a substitute for the integration tests that pin your guards in production.
+
+## How it works under the hood
+
+The data model is small enough to describe in one paragraph. \`SimulationConfig\` is \`{ subject, effects, templateId }\`. Each effect is \`{ description?, patches?, mockRequest? }\`. The simulator store carries the subject as live state, deep-clones it on initialization, and on each \`apply()\` runs the matching effect's patches against a clone — preserving the *before* snapshot on the step. The mock request is resolved with a tiny \`{{ path }}\` interpolator that walks the subject via JSON-pointer-style segments and substitutes string and JSON values. Pure functions, fully sandboxed, no \`eval\`.
+
+The whole thing is built on the same [\`symflow\` engine](/blog/symflow-workflow-engine-for-nodejs) that powers Symfony-compatible runtime. The marking is still a Symfony marking. The events still fire in Symfony's order. The subject is a layer the simulator adds on top — the engine itself is unchanged.
+
+## Try it
+
+1. Open the [editor](/editor) and either build a workflow or load an existing one.
+2. Click **Simulate**.
+3. Switch to the **Scenario** tab and click **Publishing an article**.
+4. Switch back to **Steps** and walk \`submit_for_review\` → \`approve\` → \`publish\`.
+5. Click any history row.
+
+If you have already shared a workflow publicly, open its \`/w/[shareId]\` page — your viewers can now play through whatever scenario you saved.
+
+## What is next
+
+The natural follow-ups are user-supplied scenarios via share links (\`?scenario=template-id\` to override the saved one), per-place initial-state branches (so you can simulate "what if this article *started* in pending_review?"), and a record-and-replay button that captures a real run from your app and lets you scrub through it. Open issues if any of those would help.
+
+Until then: design the workflow, save the scenario, share the link, watch your reviewer click through it without ever opening a YAML file.`,
+    },
+    {
         slug: "embed-workflows-anywhere",
         title: "Embed SymFlowBuilder Workflows in Any README, Doc, or Wiki",
         date: "2026-04-28",

--- a/lib/schemas/workflow.ts
+++ b/lib/schemas/workflow.ts
@@ -10,6 +10,7 @@ export const createWorkflowSchema = z.object({
     type: z.enum(WORKFLOW_TYPES).optional(),
     graphJson: z.unknown().optional(),
     yamlCache: z.string().optional(),
+    simulationConfig: z.unknown().nullish(),
 });
 
 export const updateWorkflowSchema = z.object({
@@ -19,6 +20,7 @@ export const updateWorkflowSchema = z.object({
     type: z.enum(WORKFLOW_TYPES).optional(),
     graphJson: z.unknown().optional(),
     yamlCache: z.string().optional(),
+    simulationConfig: z.unknown().nullish(),
 });
 
 export const createVersionSchema = z.object({

--- a/lib/simulation/apply-effect.ts
+++ b/lib/simulation/apply-effect.ts
@@ -1,0 +1,235 @@
+import type {
+    FieldPatch,
+    JsonValue,
+    MockRequest,
+    SimulationConfig,
+    TransitionEffect,
+} from "@/types/simulation";
+
+function parsePath(path: string): string[] {
+    return path
+        .replace(/^\$?\.?/, "")
+        .split(/\.|\[(\d+)\]/)
+        .filter((seg): seg is string => Boolean(seg) && seg.length > 0);
+}
+
+function isObject(v: unknown): v is Record<string, JsonValue> {
+    return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function setAt(
+    target: Record<string, JsonValue> | JsonValue[],
+    segments: string[],
+    value: JsonValue
+): void {
+    if (segments.length === 0) return;
+    let cursor: JsonValue = target as JsonValue;
+    for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+        const next = segments[i + 1];
+        const wantArray = /^\d+$/.test(next);
+        if (Array.isArray(cursor)) {
+            const idx = Number(seg);
+            if (
+                cursor[idx] === null ||
+                cursor[idx] === undefined ||
+                typeof cursor[idx] !== "object"
+            ) {
+                cursor[idx] = wantArray ? [] : {};
+            }
+            cursor = cursor[idx];
+        } else if (isObject(cursor)) {
+            if (
+                cursor[seg] === null ||
+                cursor[seg] === undefined ||
+                typeof cursor[seg] !== "object"
+            ) {
+                cursor[seg] = wantArray ? [] : {};
+            }
+            cursor = cursor[seg];
+        }
+    }
+    const last = segments[segments.length - 1];
+    if (Array.isArray(cursor)) {
+        cursor[Number(last)] = value;
+    } else if (isObject(cursor)) {
+        cursor[last] = value;
+    }
+}
+
+function pushAt(
+    target: Record<string, JsonValue> | JsonValue[],
+    segments: string[],
+    value: JsonValue
+): void {
+    let cursor: JsonValue = target as JsonValue;
+    for (const seg of segments) {
+        if (Array.isArray(cursor)) {
+            cursor = cursor[Number(seg)];
+        } else if (isObject(cursor)) {
+            if (cursor[seg] === null || cursor[seg] === undefined) {
+                cursor[seg] = [];
+            }
+            cursor = cursor[seg];
+        }
+    }
+    if (Array.isArray(cursor)) {
+        cursor.push(value);
+    }
+}
+
+function removeAt(
+    target: Record<string, JsonValue> | JsonValue[],
+    segments: string[]
+): void {
+    if (segments.length === 0) return;
+    let cursor: JsonValue = target as JsonValue;
+    for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+        if (Array.isArray(cursor)) {
+            cursor = cursor[Number(seg)];
+        } else if (isObject(cursor)) {
+            cursor = cursor[seg];
+        }
+        if (cursor === null || cursor === undefined) return;
+    }
+    const last = segments[segments.length - 1];
+    if (Array.isArray(cursor)) {
+        cursor.splice(Number(last), 1);
+    } else if (isObject(cursor)) {
+        delete cursor[last];
+    }
+}
+
+export function deepClone<T>(value: T): T {
+    if (typeof structuredClone === "function") return structuredClone(value);
+    return JSON.parse(JSON.stringify(value));
+}
+
+export function applyPatch(
+    subject: Record<string, JsonValue>,
+    patch: FieldPatch
+): Record<string, JsonValue> {
+    const segments = parsePath(patch.path);
+    if (segments.length === 0) return subject;
+    const op = patch.op ?? "set";
+    if (op === "set") setAt(subject, segments, patch.value);
+    else if (op === "push") pushAt(subject, segments, patch.value);
+    else if (op === "remove") removeAt(subject, segments);
+    return subject;
+}
+
+export function applyEffect(
+    subject: Record<string, JsonValue>,
+    effect: TransitionEffect | undefined
+): Record<string, JsonValue> {
+    const next = deepClone(subject);
+    if (!effect?.patches) return next;
+    for (const p of effect.patches) applyPatch(next, p);
+    return next;
+}
+
+export function diffPaths(
+    before: Record<string, JsonValue>,
+    after: Record<string, JsonValue>,
+    prefix: string[] = []
+): string[] {
+    const changed: string[] = [];
+    const keys = new Set([...Object.keys(before ?? {}), ...Object.keys(after ?? {})]);
+    for (const k of keys) {
+        const a = (before as Record<string, JsonValue> | undefined)?.[k];
+        const b = (after as Record<string, JsonValue> | undefined)?.[k];
+        if (isObject(a) && isObject(b)) {
+            changed.push(...diffPaths(a, b, [...prefix, k]));
+        } else if (JSON.stringify(a) !== JSON.stringify(b)) {
+            changed.push([...prefix, k].join("."));
+        }
+    }
+    return changed;
+}
+
+export function ensureConfig(
+    config: SimulationConfig | null | undefined
+): SimulationConfig {
+    return {
+        subject: config?.subject ?? {},
+        effects: config?.effects ?? {},
+        templateId: config?.templateId,
+    };
+}
+
+function readPath(
+    subject: Record<string, JsonValue>,
+    path: string
+): JsonValue | undefined {
+    const segments = path
+        .replace(/^\$?\.?/, "")
+        .split(/\.|\[(\d+)\]/)
+        .filter((s): s is string => Boolean(s) && s.length > 0);
+    let cursor: JsonValue | undefined = subject as JsonValue;
+    for (const seg of segments) {
+        if (cursor === null || cursor === undefined) return undefined;
+        if (Array.isArray(cursor)) {
+            cursor = cursor[Number(seg)];
+        } else if (isObject(cursor)) {
+            cursor = cursor[seg];
+        } else {
+            return undefined;
+        }
+    }
+    return cursor;
+}
+
+export function interpolate(
+    template: string,
+    subject: Record<string, JsonValue>
+): string {
+    return template.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_, expr: string) => {
+        const value = readPath(subject, expr.trim());
+        if (value === undefined || value === null) return "";
+        if (typeof value === "string") return value;
+        return JSON.stringify(value);
+    });
+}
+
+function interpolateValue(
+    value: JsonValue,
+    subject: Record<string, JsonValue>
+): JsonValue {
+    if (typeof value === "string") return interpolate(value, subject);
+    if (Array.isArray(value)) {
+        return value.map((v) => interpolateValue(v, subject));
+    }
+    if (isObject(value)) {
+        const next: Record<string, JsonValue> = {};
+        for (const [k, v] of Object.entries(value)) {
+            next[k] = interpolateValue(v, subject);
+        }
+        return next;
+    }
+    return value;
+}
+
+export function resolveMockRequest(
+    request: MockRequest | undefined,
+    subject: Record<string, JsonValue>
+): MockRequest | undefined {
+    if (!request) return undefined;
+    return {
+        method: request.method,
+        url: interpolate(request.url, subject),
+        body:
+            request.body === undefined
+                ? undefined
+                : interpolateValue(request.body, subject),
+        response: request.response
+            ? {
+                  status: request.response.status,
+                  body:
+                      request.response.body === undefined
+                          ? undefined
+                          : interpolateValue(request.response.body, subject),
+              }
+            : undefined,
+    };
+}

--- a/lib/simulation/templates.ts
+++ b/lib/simulation/templates.ts
@@ -1,0 +1,132 @@
+import type { SimulationConfig } from "@/types/simulation";
+
+export interface SimulationTemplate {
+    id: string;
+    name: string;
+    description: string;
+    matches?: { transitions: string[] };
+    config: SimulationConfig;
+}
+
+export const SIMULATION_TEMPLATES: SimulationTemplate[] = [
+    {
+        id: "article-publishing",
+        name: "Publishing an article",
+        description:
+            "A blog post moves from draft to published with a reviewer in between.",
+        matches: {
+            transitions: ["submit_for_review", "approve", "publish", "reject"],
+        },
+        config: {
+            templateId: "article-publishing",
+            subject: {
+                id: "art_1042",
+                title: "My first post",
+                body: "Hello, world.",
+                author: "alice",
+                reviewer: null,
+                reviewNotes: null,
+                publishedAt: null,
+            },
+            effects: {
+                submit_for_review: {
+                    description: "Author submits the draft for editorial review.",
+                    patches: [{ path: "reviewer", value: "bob" }],
+                    mockRequest: {
+                        method: "POST",
+                        url: "/api/articles/{{id}}/submit",
+                        body: { reviewer: "bob" },
+                        response: {
+                            status: 202,
+                            body: { id: "{{id}}", status: "pending_review" },
+                        },
+                    },
+                },
+                approve: {
+                    description: "Reviewer signs off on the article.",
+                    patches: [{ path: "reviewNotes", value: "LGTM" }],
+                    mockRequest: {
+                        method: "POST",
+                        url: "/api/articles/{{id}}/approve",
+                        body: { notes: "LGTM" },
+                        response: {
+                            status: 200,
+                            body: { id: "{{id}}", status: "approved" },
+                        },
+                    },
+                },
+                reject: {
+                    description: "Reviewer requests changes.",
+                    patches: [
+                        { path: "reviewNotes", value: "Needs rework" },
+                        { path: "reviewer", value: null },
+                    ],
+                    mockRequest: {
+                        method: "POST",
+                        url: "/api/articles/{{id}}/reject",
+                        body: { notes: "Needs rework" },
+                        response: {
+                            status: 200,
+                            body: { id: "{{id}}", status: "rejected" },
+                        },
+                    },
+                },
+                publish: {
+                    description: "Article goes live.",
+                    patches: [
+                        {
+                            path: "publishedAt",
+                            value: "2026-04-30T10:00:00.000Z",
+                        },
+                    ],
+                    mockRequest: {
+                        method: "POST",
+                        url: "/api/articles/{{id}}/publish",
+                        response: {
+                            status: 200,
+                            body: {
+                                id: "{{id}}",
+                                status: "published",
+                                url: "https://example.com/blog/{{id}}",
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    {
+        id: "order-fulfillment",
+        name: "Order fulfillment",
+        description: "An e-commerce order moves through pick, pack, and ship.",
+        matches: { transitions: ["pay", "pack", "ship", "deliver", "cancel"] },
+        config: {
+            templateId: "order-fulfillment",
+            subject: {
+                orderId: "ORD-1042",
+                customer: "alice@example.com",
+                amount: 79.5,
+                items: 3,
+                tracking: null,
+            },
+            effects: {
+                pay: { patches: [{ path: "paidAt", value: "2026-04-30T09:00:00.000Z" }] },
+                pack: { patches: [{ path: "packedBy", value: "warehouse-1" }] },
+                ship: {
+                    patches: [{ path: "tracking", value: "1Z999AA10123456784" }],
+                },
+                deliver: {
+                    patches: [{ path: "deliveredAt", value: "2026-05-02T14:30:00.000Z" }],
+                },
+                cancel: {
+                    patches: [{ path: "cancelReason", value: "customer-request" }],
+                },
+            },
+        },
+    },
+];
+
+export function findTemplate(id: string | undefined): SimulationTemplate | null {
+    if (!id) return null;
+    return SIMULATION_TEMPLATES.find((t) => t.id === id) ?? null;
+}

--- a/packages/db/prisma/migrations/20260430000000_add_workflow_simulation_config/migration.sql
+++ b/packages/db/prisma/migrations/20260430000000_add_workflow_simulation_config/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workflow" ADD COLUMN     "simulationConfig" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Workflow {
   type           String   @default("workflow")
   graphJson      Json
   yamlCache      String?
+  simulationConfig Json?
   shareId        String?  @unique
   isPublic       Boolean  @default(false)
   createdAt      DateTime @default(now())

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const globalForPrisma = globalThis as unknown as {
@@ -15,6 +15,8 @@ export const prisma =
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 
+export { Prisma };
+
 export type {
     User,
     Account,
@@ -24,5 +26,4 @@ export type {
     WorkflowVersion,
     WorkflowCollaborator,
     BlogPost,
-    Prisma,
 } from "@prisma/client";

--- a/stores/editor.ts
+++ b/stores/editor.ts
@@ -30,6 +30,7 @@ import {
 } from "symflow/react-flow";
 import type { AccessLevel } from "@/types/collaboration";
 import type { SubWorkflowNodeData } from "@/types/subworkflow";
+import type { SimulationConfig } from "@/types/simulation";
 import { uid, uniqueName } from "@/lib/utils";
 
 function shallowEqualPatch<T extends object>(
@@ -58,7 +59,9 @@ interface EditorStore {
     selectedNodeId: string | null;
     selectedEdgeId: string | null;
     accessLevel: AccessLevel | null;
+    simulationConfig: SimulationConfig | null;
     setAccessLevel: (level: AccessLevel | null) => void;
+    setSimulationConfig: (config: SimulationConfig | null) => void;
 
     // React Flow handlers
     onNodesChange: OnNodesChange;
@@ -97,7 +100,12 @@ interface EditorStore {
     importYaml: (yamlString: string) => void;
     importJson: (jsonString: string) => void;
     importFromUrl: (url: string) => Promise<void>;
-    loadFromJson: (data: { nodes: Node[]; edges: Edge[]; meta: WorkflowMeta }) => void;
+    loadFromJson: (data: {
+        nodes: Node[];
+        edges: Edge[];
+        meta: WorkflowMeta;
+        simulationConfig?: SimulationConfig | null;
+    }) => void;
     reset: () => void;
 
     // Setters for ReactFlow
@@ -113,7 +121,9 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     selectedNodeId: null,
     selectedEdgeId: null,
     accessLevel: null,
+    simulationConfig: null,
     setAccessLevel: (level) => set({ accessLevel: level }),
+    setSimulationConfig: (config) => set({ simulationConfig: config }),
 
     onNodesChange: (changes) => {
         set({ nodes: applyNodeChanges(changes, get().nodes) });
@@ -335,7 +345,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         }
     },
 
-    loadFromJson: ({ nodes, edges, meta }) => {
+    loadFromJson: ({ nodes, edges, meta, simulationConfig }) => {
         // Migrate old edge-based workflows to node-based format
         const migrated = migrateGraphData({ nodes, edges });
         set({
@@ -345,6 +355,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             history: { past: [], future: [] },
             selectedNodeId: null,
             selectedEdgeId: null,
+            simulationConfig: simulationConfig ?? null,
         });
     },
 
@@ -356,6 +367,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             workflowMeta: { ...DEFAULT_WORKFLOW_META },
             selectedNodeId: null,
             selectedEdgeId: null,
+            simulationConfig: null,
         });
     },
 

--- a/stores/simulator.ts
+++ b/stores/simulator.ts
@@ -12,6 +12,19 @@ import {
     type WorkflowEvent,
 } from "symflow/engine";
 import { buildDefinition } from "symflow/react-flow";
+import type {
+    FieldPatch,
+    JsonValue,
+    MockRequest,
+    SimulationConfig,
+    TransitionEffect,
+} from "@/types/simulation";
+import {
+    applyEffect,
+    deepClone,
+    ensureConfig,
+    resolveMockRequest,
+} from "@/lib/simulation/apply-effect";
 
 export interface SimulationStep {
     transitionName: string;
@@ -19,14 +32,22 @@ export interface SimulationStep {
     toMarking: Marking;
     events: WorkflowEvent[];
     timestamp: number;
+    subjectBefore: Record<string, JsonValue>;
+    subjectAfter: Record<string, JsonValue>;
+    effect?: TransitionEffect;
+    resolvedRequest?: MockRequest;
 }
+
+export type SimulatorTab = "steps" | "scenario" | "inspector";
 
 interface SimulatorStore {
     // Mode
     active: boolean;
+    tab: SimulatorTab;
 
     // Engine
     engine: WorkflowEngine | null;
+    meta: WorkflowMeta | null;
 
     // State
     marking: Marking;
@@ -38,12 +59,24 @@ interface SimulatorStore {
     // Guard overrides: transition name → blocked (true = guard blocks)
     blockedGuards: Record<string, boolean>;
 
+    // Scenario
+    config: SimulationConfig;
+    initialSubject: Record<string, JsonValue>;
+    subject: Record<string, JsonValue>;
+    selectedStepIndex: number | null;
+    configDirty: boolean;
+
     // Auto-play
     autoPlaying: boolean;
     autoPlaySpeed: number;
 
     // Actions
-    initialize: (nodes: Node[], edges: Edge[], meta: WorkflowMeta) => void;
+    initialize: (
+        nodes: Node[],
+        edges: Edge[],
+        meta: WorkflowMeta,
+        config?: SimulationConfig | null
+    ) => void;
     activate: () => void;
     deactivate: () => void;
     applyTransition: (transitionName: string) => void;
@@ -52,21 +85,61 @@ interface SimulatorStore {
     toggleAutoPlay: () => void;
     setAutoPlaySpeed: (ms: number) => void;
     toggleGuard: (transitionName: string) => void;
+    setTab: (tab: SimulatorTab) => void;
+    setSelectedStep: (index: number | null) => void;
+    setSubject: (subject: Record<string, JsonValue>) => void;
+    setEffect: (transitionName: string, effect: TransitionEffect | null) => void;
+    addEffectPatch: (transitionName: string, patch: FieldPatch) => void;
+    updateEffectPatch: (
+        transitionName: string,
+        index: number,
+        patch: Partial<FieldPatch>
+    ) => void;
+    removeEffectPatch: (transitionName: string, index: number) => void;
+    loadTemplate: (config: SimulationConfig) => void;
+    markConfigSaved: () => void;
+}
+
+function markingValue(marking: Marking, type: WorkflowMeta["type"]): JsonValue {
+    const places = Object.entries(marking)
+        .filter(([, count]) => count > 0)
+        .map(([name]) => name);
+    if (type === "state_machine") return places[0] ?? null;
+    return places;
+}
+
+function injectMarking(
+    subject: Record<string, JsonValue>,
+    marking: Marking,
+    meta: WorkflowMeta | null
+): Record<string, JsonValue> {
+    if (!meta?.property) return subject;
+    return {
+        ...subject,
+        [meta.property]: markingValue(marking, meta.type),
+    };
 }
 
 export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
     active: false,
+    tab: "steps",
     engine: null,
+    meta: null,
     marking: {},
     enabledTransitions: [],
     history: [],
     validation: null,
     analysis: null,
     blockedGuards: {},
+    config: { subject: {}, effects: {} },
+    initialSubject: {},
+    subject: {},
+    selectedStepIndex: null,
+    configDirty: false,
     autoPlaying: false,
     autoPlaySpeed: 1000,
 
-    initialize: (nodes, edges, meta) => {
+    initialize: (nodes, edges, meta, config) => {
         const definition = buildDefinition(nodes, edges, meta);
         const validation = validateDefinition(definition);
         const analysis = analyzeWorkflow(definition);
@@ -86,14 +159,28 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
             },
         });
 
+        const fullConfig = ensureConfig(config);
+        const startMarking = engine.getMarking();
+        const initialSubject = injectMarking(
+            deepClone(fullConfig.subject),
+            startMarking,
+            meta
+        );
+
         set({
             engine,
-            marking: engine.getMarking(),
+            meta,
+            marking: startMarking,
             enabledTransitions: engine.getEnabledTransitions(),
             history: [],
             validation,
             analysis,
             blockedGuards,
+            config: fullConfig,
+            initialSubject,
+            subject: deepClone(initialSubject),
+            selectedStepIndex: null,
+            configDirty: false,
         });
     },
 
@@ -103,6 +190,7 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
         set({
             active: false,
             engine: null,
+            meta: null,
             marking: {},
             enabledTransitions: [],
             history: [],
@@ -110,13 +198,16 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
             analysis: null,
             blockedGuards: {},
             autoPlaying: false,
+            selectedStepIndex: null,
+            tab: "steps",
         }),
 
     applyTransition: (transitionName) => {
-        const { engine } = get();
+        const { engine, subject, config, meta } = get();
         if (!engine) return;
 
         const fromMarking = engine.getMarking();
+        const subjectBefore = deepClone(subject);
 
         // Collect events fired during this transition
         const firedEvents: WorkflowEvent[] = [];
@@ -134,9 +225,21 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
 
         try {
             const toMarking = engine.apply(transitionName);
+            const effect = config.effects?.[transitionName];
+            const patched = applyEffect(subjectBefore, effect);
+            // Mirror Symfony's marking_store behavior: write the new marking
+            // into subject[meta.property] so the Inspector diff shows the
+            // state change as data, not just on the canvas.
+            const subjectAfter = injectMarking(patched, toMarking, meta);
+            const resolvedRequest = resolveMockRequest(
+                effect?.mockRequest,
+                subjectBefore
+            );
+
             set((state) => ({
                 marking: toMarking,
                 enabledTransitions: engine.getEnabledTransitions(),
+                subject: subjectAfter,
                 history: [
                     ...state.history,
                     {
@@ -145,6 +248,10 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
                         toMarking,
                         events: firedEvents,
                         timestamp: Date.now(),
+                        subjectBefore,
+                        subjectAfter,
+                        effect,
+                        resolvedRequest,
                     },
                 ],
             }));
@@ -156,14 +263,17 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
     },
 
     reset: () => {
-        const { engine } = get();
+        const { engine, initialSubject, meta } = get();
         if (!engine) return;
         engine.reset();
+        const startMarking = engine.getMarking();
         set({
-            marking: engine.getMarking(),
+            marking: startMarking,
             enabledTransitions: engine.getEnabledTransitions(),
             history: [],
             autoPlaying: false,
+            subject: injectMarking(deepClone(initialSubject), startMarking, meta),
+            selectedStepIndex: null,
         });
     },
 
@@ -177,6 +287,8 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
             marking: prev.fromMarking,
             enabledTransitions: engine.getEnabledTransitions(),
             history: history.slice(0, -1),
+            subject: deepClone(prev.subjectBefore),
+            selectedStepIndex: null,
         });
     },
 
@@ -195,8 +307,113 @@ export const useSimulatorStore = create<SimulatorStore>((set, get) => ({
     },
 
     toggleAutoPlay: () => {
-        set((state) => ({ autoPlaying: !state.autoPlaying }));
+        set((state) => ({
+            autoPlaying: !state.autoPlaying,
+            // Surface the action: when starting auto-play from another tab,
+            // jump to Steps so the user sees the marking and history change.
+            tab: !state.autoPlaying ? "steps" : state.tab,
+        }));
     },
 
     setAutoPlaySpeed: (ms) => set({ autoPlaySpeed: ms }),
+
+    setTab: (tab) => set({ tab }),
+
+    setSelectedStep: (index) => set({ selectedStepIndex: index }),
+
+    setSubject: (subject) =>
+        set((state) => {
+            const cleaned = deepClone(subject);
+            const initialSubject = injectMarking(
+                deepClone(subject),
+                state.marking,
+                state.meta
+            );
+            return {
+                config: { ...state.config, subject: cleaned },
+                initialSubject,
+                subject:
+                    state.history.length === 0
+                        ? deepClone(initialSubject)
+                        : state.subject,
+                configDirty: true,
+            };
+        }),
+
+    setEffect: (transitionName, effect) =>
+        set((state) => {
+            const effects = { ...(state.config.effects ?? {}) };
+            if (effect === null) delete effects[transitionName];
+            else effects[transitionName] = effect;
+            return {
+                config: { ...state.config, effects },
+                configDirty: true,
+            };
+        }),
+
+    addEffectPatch: (transitionName, patch) =>
+        set((state) => {
+            const effects = { ...(state.config.effects ?? {}) };
+            const existing = effects[transitionName] ?? {};
+            effects[transitionName] = {
+                ...existing,
+                patches: [...(existing.patches ?? []), patch],
+            };
+            return {
+                config: { ...state.config, effects },
+                configDirty: true,
+            };
+        }),
+
+    updateEffectPatch: (transitionName, index, patch) =>
+        set((state) => {
+            const effects = { ...(state.config.effects ?? {}) };
+            const existing = effects[transitionName];
+            if (!existing?.patches) return state;
+            const patches = existing.patches.map((p, i) =>
+                i === index ? { ...p, ...patch } : p
+            );
+            effects[transitionName] = { ...existing, patches };
+            return {
+                config: { ...state.config, effects },
+                configDirty: true,
+            };
+        }),
+
+    removeEffectPatch: (transitionName, index) =>
+        set((state) => {
+            const effects = { ...(state.config.effects ?? {}) };
+            const existing = effects[transitionName];
+            if (!existing?.patches) return state;
+            const patches = existing.patches.filter((_, i) => i !== index);
+            effects[transitionName] = { ...existing, patches };
+            return {
+                config: { ...state.config, effects },
+                configDirty: true,
+            };
+        }),
+
+    loadTemplate: (config) => {
+        const { engine, meta } = get();
+        if (engine) engine.reset();
+        const startMarking = engine ? engine.getMarking() : {};
+        const initialSubject = injectMarking(
+            deepClone(config.subject),
+            startMarking,
+            meta
+        );
+        set({
+            config: ensureConfig(config),
+            initialSubject,
+            subject: deepClone(initialSubject),
+            history: [],
+            selectedStepIndex: null,
+            configDirty: true,
+            marking: startMarking,
+            enabledTransitions: engine ? engine.getEnabledTransitions() : [],
+            autoPlaying: false,
+        });
+    },
+
+    markConfigSaved: () => set({ configDirty: false }),
 }));

--- a/types/simulation.ts
+++ b/types/simulation.ts
@@ -1,0 +1,39 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export interface FieldPatch {
+    path: string;
+    value: JsonValue;
+    op?: "set" | "push" | "remove";
+}
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface MockResponse {
+    status: number;
+    body?: JsonValue;
+}
+
+export interface MockRequest {
+    method: HttpMethod;
+    url: string;
+    body?: JsonValue;
+    response?: MockResponse;
+}
+
+export interface TransitionEffect {
+    description?: string;
+    patches?: FieldPatch[];
+    mockRequest?: MockRequest;
+}
+
+export interface SimulationConfig {
+    subject: Record<string, JsonValue>;
+    effects?: Record<string, TransitionEffect>;
+    templateId?: string;
+}
+
+export const EMPTY_SIMULATION_CONFIG: SimulationConfig = {
+    subject: {},
+    effects: {},
+};


### PR DESCRIPTION
## Summary

- Adds a **subject + per-transition effects** layer on top of the simulator. Workflows now persist a `simulationConfig` JSONB column carrying a starting subject, patches that mutate it on each transition, and optional mock HTTP requests with `{{ subject.path }}` interpolation.
- New **Steps / Scenario / Inspector** tabs in the simulator panel. Inspector shows before/after subject diff with changed-field highlighting, plus a resolved request/response panel for any step that had a mock request. Marking is auto-injected into `subject[meta.property]` to mirror Symfony's marking_store.
- **Embed view is now interactive** — `/embed/[shareId]?play=1` auto-starts the simulator, so docs sites can drop in a runnable demo iframe.
- Simulator panel relocated from a bottom-center popover to a right-side sheet (full canvas height). The global FeedbackFab dodges to the bottom-left while the simulator is active.
- Built-in templates: **Publishing an article** and **Order fulfillment**. Two new blog posts cover the feature and a worked walkthrough.
- Fixes: JSON textareas no longer clobber whitespace or jump cursor mid-edit; `loadTemplate` resets the engine; auto-play fires the first step immediately and switches to the Steps tab.

## Migration

Adds a new column `Workflow.simulationConfig JSONB`. Migration is safe and additive — existing rows get `NULL`.

```
pnpm prisma:migrate
```

## Test plan

- [ ] `pnpm prisma:migrate` applies cleanly
- [ ] Editor → click **Simulate** → switch to **Scenario** tab → click **Publishing an article** template
- [ ] Switch to **Steps** → walk `submit_for_review` → `approve` → `publish`
- [ ] Click any history row → **Inspector** shows before/after subject diff (including `marking`/`status` field) and resolved mock request `POST /api/articles/art_1042/...`
- [ ] Click **Restart** → engine resets to initial marking with the saved scenario intact
- [ ] Toggle **Auto-play** while on Scenario tab → panel snaps to Steps and first transition fires immediately
- [ ] Save a scenario → reload editor → scenario rehydrates from `simulationConfig`
- [ ] Make a workflow public → open `/w/[shareId]` → click **Simulate** → walk the saved scenario without signing in
- [ ] Open `/embed/[shareId]?play=1` → simulator auto-starts; FAB sits bottom-left, not under the sheet
- [ ] In the mock request body editor, type \`{\`, press Enter, type \`}\` — cursor stays in place, content not stripped
- [ ] Confirm the two new blog posts render at \`/blog/playable-scenarios-mock-data-in-the-simulator\` and \`/blog/walkthrough-publishing-an-article-scenario\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)