### PR TITLE
feat(embed): highlight live marking via ?marking= query param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,5 +116,5 @@ If a component doesn't exist, build it in `/components/ui/` using Radix primitiv
 - Iframe embed: `/embed/[shareId]` — minimal chrome, fit-to-view canvas, branding watermark
 - Both routes resolve via `Workflow.shareId` (unique) and require `isPublic = true`
 - `/embed/*` ships with `Content-Security-Policy: frame-ancestors *` (set in `next.config.ts`) — do not block-list it; it is the only path explicitly meant to be framed
-- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark
+- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark, `?marking=place_a,place_b` highlights the listed places (read by `EmbeddedWorkflowView` → `useExternalMarkingStore` → `StateNode`); host apps rebuild the iframe `src` to push live state from their own marking store
 - Mermaid copy buttons (dashboard + shared view) wrap output in a fenced ` ```mermaid ` block so paste-into-README "just works"

--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -21,6 +21,7 @@ import { SubWorkflowNode } from "@/components/editor/nodes/SubWorkflowNode";
 import { ConnectorEdge } from "@/components/editor/edges/ConnectorEdge";
 import { SimulatorPanel } from "@/components/editor/panels/SimulatorPanel";
 import { useSimulatorStore } from "@/stores/simulator";
+import { useExternalMarkingStore } from "@/stores/externalMarking";
 import type { WorkflowMeta } from "symflow";
 import type { SimulationConfig } from "@/types/simulation";
 import { migrateGraphData } from "symflow/react-flow";
@@ -45,6 +46,7 @@ interface Props {
     showMiniMap: boolean;
     showBranding: boolean;
     autoPlay: boolean;
+    externalMarking: string[];
 }
 
 export function EmbeddedWorkflowView({
@@ -57,6 +59,7 @@ export function EmbeddedWorkflowView({
     showMiniMap,
     showBranding,
     autoPlay,
+    externalMarking,
 }: Props) {
     const rawNodes = (graphJson.nodes as Node[]) ?? [];
     const rawEdges = (graphJson.edges as Edge[]) ?? [];
@@ -76,6 +79,8 @@ export function EmbeddedWorkflowView({
     const simInitialize = useSimulatorStore((s) => s.initialize);
     const simActivate = useSimulatorStore((s) => s.activate);
     const simDeactivate = useSimulatorStore((s) => s.deactivate);
+    const setExternalPlaces = useExternalMarkingStore((s) => s.setPlaces);
+    const clearExternalPlaces = useExternalMarkingStore((s) => s.clear);
 
     useEffect(() => {
         if (autoPlay && !simActive) {
@@ -93,6 +98,13 @@ export function EmbeddedWorkflowView({
         // Run once on mount; deactivate on unmount.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+        setExternalPlaces(externalMarking);
+        return () => {
+            clearExternalPlaces();
+        };
+    }, [externalMarking, setExternalPlaces, clearExternalPlaces]);
 
     const handleToggle = () => {
         if (simActive) {

--- a/app/embed/[shareId]/page.tsx
+++ b/app/embed/[shareId]/page.tsx
@@ -53,6 +53,7 @@ export default async function EmbedWorkflowPage({
     const showMiniMap = query.minimap !== "0";
     const showBranding = query.branding !== "0";
     const autoPlay = query.play === "1";
+    const externalMarking = parseMarkingParam(query.marking);
 
     return (
         <EmbeddedWorkflowView
@@ -67,6 +68,17 @@ export default async function EmbedWorkflowPage({
             showMiniMap={showMiniMap}
             showBranding={showBranding}
             autoPlay={autoPlay}
+            externalMarking={externalMarking}
         />
     );
+}
+
+function parseMarkingParam(raw: string | string[] | undefined): string[] {
+    if (!raw) return [];
+    const values = Array.isArray(raw) ? raw : [raw];
+    const places = values
+        .flatMap((v) => v.split(","))
+        .map((s) => s.trim())
+        .filter((s) => /^[a-z][a-z0-9_]*$/i.test(s));
+    return Array.from(new Set(places));
 }

--- a/components/editor/nodes/StateNode.tsx
+++ b/components/editor/nodes/StateNode.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { StateNodeData } from "symflow/react-flow";
 import { useSimulatorStore } from "@/stores/simulator";
+import { useExternalMarkingStore } from "@/stores/externalMarking";
 
 export const StateNode = memo(
     ({ data, selected }: NodeProps & { data: StateNodeData }) => {
@@ -11,8 +12,12 @@ export const StateNode = memo(
         const tokenCount = useSimulatorStore((s) =>
             s.active ? (s.marking[data.label] ?? 0) : 0
         );
-        const isMarked = simActive && tokenCount > 0;
-        const isDimmed = simActive && tokenCount === 0;
+        const externalMarked = useExternalMarkingStore((s) => s.places.has(data.label));
+        const externalActive = useExternalMarkingStore((s) => s.places.size > 0);
+        const isMarked = (simActive && tokenCount > 0) || externalMarked;
+        const isDimmed =
+            (simActive && tokenCount === 0 && !externalMarked) ||
+            (!simActive && externalActive && !externalMarked);
 
         const bgColor = data.metadata?.bg_color;
         const description = data.metadata?.description;

--- a/stores/externalMarking.ts
+++ b/stores/externalMarking.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface ExternalMarkingState {
+    places: Set<string>;
+    setPlaces: (places: string[]) => void;
+    clear: () => void;
+}
+
+export const useExternalMarkingStore = create<ExternalMarkingState>((set) => ({
+    places: new Set<string>(),
+    setPlaces: (places) => set({ places: new Set(places) }),
+    clear: () => set({ places: new Set<string>() }),
+}));


### PR DESCRIPTION
## Summary

- Adds a new `?marking=place_a,place_b` query param to `/embed/[shareId]` so iframe embeds can mirror the host application's runtime workflow state — same green-pulse highlight the simulator uses.
- New `useExternalMarkingStore` feeds `StateNode` so the highlight is reactive to URL changes.
- `EmbeddedWorkflowView` parses the query param and pushes the active places into the store on mount + on URL update.
- CLAUDE.md updated to document the new param alongside `?minimap=0` and `?branding=0`.

## Why

The two `symflow-laravel` showcase apps ([expense-approval](https://github.com/vandetho/symflow-laravel-expense-approval), [issue-tracker](https://github.com/vandetho/symflow-laravel-issue-tracker)) embed the canonical SymFlowBuilder canvas as an iframe on each detail page. Today that canvas is static — same diagram regardless of which record you're looking at. After this PR, the host can rebuild the iframe `src` per record (e.g. `?marking=legal_review,finance_review,manager_approved`) and the canvas lights up the same places the host's own diagram does. End result: iframe behaves like a live "canonical" version of the per-record Mermaid render.

## Test plan

- [x] Open `/embed/{shareId}?marking=foo,bar` — `foo` and `bar` light up
- [x] Change the param at runtime (host rebuilds `src`) — highlight updates
- [x] No `?marking` param → behaves exactly like before (no regression)
- [x] Both `&minimap=0` and `&branding=0` still respected when combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)