### PR TITLE
feat(embed): highlight live marking via ?marking= query param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,5 +116,5 @@ If a component doesn't exist, build it in `/components/ui/` using Radix primitiv
 - Iframe embed: `/embed/[shareId]` — minimal chrome, fit-to-view canvas, branding watermark
 - Both routes resolve via `Workflow.shareId` (unique) and require `isPublic = true`
 - `/embed/*` ships with `Content-Security-Policy: frame-ancestors *` (set in `next.config.ts`) — do not block-list it; it is the only path explicitly meant to be framed
-- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark
+- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark, `?marking=place_a,place_b` highlights the listed places (read by `EmbeddedWorkflowView` → `useExternalMarkingStore` → `StateNode`); host apps rebuild the iframe `src` to push live state from their own marking store
 - Mermaid copy buttons (dashboard + shared view) wrap output in a fenced ` ```mermaid ` block so paste-into-README "just works"

--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -21,6 +21,7 @@ import { SubWorkflowNode } from "@/components/editor/nodes/SubWorkflowNode";
 import { ConnectorEdge } from "@/components/editor/edges/ConnectorEdge";
 import { SimulatorPanel } from "@/components/editor/panels/SimulatorPanel";
 import { useSimulatorStore } from "@/stores/simulator";
+import { useExternalMarkingStore } from "@/stores/externalMarking";
 import type { WorkflowMeta } from "symflow";
 import type { SimulationConfig } from "@/types/simulation";
 import { migrateGraphData } from "symflow/react-flow";
@@ -45,6 +46,7 @@ interface Props {
     showMiniMap: boolean;
     showBranding: boolean;
     autoPlay: boolean;
+    externalMarking: string[];
 }
 
 export function EmbeddedWorkflowView({
@@ -57,6 +59,7 @@ export function EmbeddedWorkflowView({
     showMiniMap,
     showBranding,
     autoPlay,
+    externalMarking,
 }: Props) {
     const rawNodes = (graphJson.nodes as Node[]) ?? [];
     const rawEdges = (graphJson.edges as Edge[]) ?? [];
@@ -76,6 +79,8 @@ export function EmbeddedWorkflowView({
     const simInitialize = useSimulatorStore((s) => s.initialize);
     const simActivate = useSimulatorStore((s) => s.activate);
     const simDeactivate = useSimulatorStore((s) => s.deactivate);
+    const setExternalPlaces = useExternalMarkingStore((s) => s.setPlaces);
+    const clearExternalPlaces = useExternalMarkingStore((s) => s.clear);
 
     useEffect(() => {
         if (autoPlay && !simActive) {
@@ -93,6 +98,13 @@ export function EmbeddedWorkflowView({
         // Run once on mount; deactivate on unmount.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+        setExternalPlaces(externalMarking);
+        return () => {
+            clearExternalPlaces();
+        };
+    }, [externalMarking, setExternalPlaces, clearExternalPlaces]);
 
     const handleToggle = () => {
         if (simActive) {

--- a/app/embed/[shareId]/page.tsx
+++ b/app/embed/[shareId]/page.tsx
@@ -53,6 +53,7 @@ export default async function EmbedWorkflowPage({
     const showMiniMap = query.minimap !== "0";
     const showBranding = query.branding !== "0";
     const autoPlay = query.play === "1";
+    const externalMarking = parseMarkingParam(query.marking);
 
     return (
         <EmbeddedWorkflowView
@@ -67,6 +68,17 @@ export default async function EmbedWorkflowPage({
             showMiniMap={showMiniMap}
             showBranding={showBranding}
             autoPlay={autoPlay}
+            externalMarking={externalMarking}
         />
     );
+}
+
+function parseMarkingParam(raw: string | string[] | undefined): string[] {
+    if (!raw) return [];
+    const values = Array.isArray(raw) ? raw : [raw];
+    const places = values
+        .flatMap((v) => v.split(","))
+        .map((s) => s.trim())
+        .filter((s) => /^[a-z][a-z0-9_]*$/i.test(s));
+    return Array.from(new Set(places));
 }

--- a/components/editor/nodes/StateNode.tsx
+++ b/components/editor/nodes/StateNode.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { StateNodeData } from "symflow/react-flow";
 import { useSimulatorStore } from "@/stores/simulator";
+import { useExternalMarkingStore } from "@/stores/externalMarking";
 
 export const StateNode = memo(
     ({ data, selected }: NodeProps & { data: StateNodeData }) => {
@@ -11,8 +12,12 @@ export const StateNode = memo(
         const tokenCount = useSimulatorStore((s) =>
             s.active ? (s.marking[data.label] ?? 0) : 0
         );
-        const isMarked = simActive && tokenCount > 0;
-        const isDimmed = simActive && tokenCount === 0;
+        const externalMarked = useExternalMarkingStore((s) => s.places.has(data.label));
+        const externalActive = useExternalMarkingStore((s) => s.places.size > 0);
+        const isMarked = (simActive && tokenCount > 0) || externalMarked;
+        const isDimmed =
+            (simActive && tokenCount === 0 && !externalMarked) ||
+            (!simActive && externalActive && !externalMarked);
 
         const bgColor = data.metadata?.bg_color;
         const description = data.metadata?.description;

--- a/stores/externalMarking.ts
+++ b/stores/externalMarking.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface ExternalMarkingState {
+    places: Set<string>;
+    setPlaces: (places: string[]) => void;
+    clear: () => void;
+}
+
+export const useExternalMarkingStore = create<ExternalMarkingState>((set) => ({
+    places: new Set<string>(),
+    setPlaces: (places) => set({ places: new Set(places) }),
+    clear: () => set({ places: new Set<string>() }),
+}));


### PR DESCRIPTION
## Summary

- Embed iframes can now light up active places via a new `?marking=place_a,place_b` query param, so host apps can mirror their runtime workflow state in the embedded canvas.
- New `useExternalMarkingStore` (small Zustand store) is read by `StateNode` alongside the existing simulator store — same green-pulse highlight, no new visual language.
- Updates `CLAUDE.md` to document the param next to the existing `?minimap=` and `?branding=` ones.

Motivating use case: the `symflow-laravel-expense-approval` and `symflow-laravel-issue-tracker` showcases embed the canvas at the bottom of each detail page. Before this, the canvas was a static reference. After this, Livewire re-renders the iframe `src` whenever `Workflow::apply()` updates the model's marking, so the embed visibly tracks the live state of the entity being viewed.

## How a host uses it

```blade
<iframe src="https://symflowbuilder.com/embed/9e50940e6f0e0d02?marking={{ implode(',', array_keys($expense->marking)) }}&branding=0"></iframe>
```

Param parser accepts both comma-separated (`?marking=a,b,c`) and repeated-key (`?marking=a&marking=b`) forms, filters out invalid identifiers via the same snake_case regex used elsewhere in the project, and dedupes.

## Test plan

- [ ] `/embed/<shareId>?marking=foo,bar` lights up the matching places in success-green and dims the rest, matching the simulator highlight
- [ ] `/embed/<shareId>` (no `?marking`) renders unchanged
- [ ] `/embed/<shareId>?marking=` and `/embed/<shareId>?marking=,,,` are no-ops
- [ ] Editor and `/w/<shareId>` are unaffected (the new store stays empty there)
- [ ] Regex filter rejects junk inputs cleanly (e.g. `?marking=<script>` is dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)