### PR TITLE
fix(embed): improve readability with bg lift, zoom floor, and brighter dots

### DIFF
--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -121,7 +121,7 @@ export function EmbeddedWorkflowView({
     };
 
     return (
-        <div className="h-screen w-screen relative bg-[#11111c]">
+        <div className="h-screen w-screen relative bg-[#1a1a2e]">
             <ReactFlowProvider>
                 <ReactFlow
                     nodes={nodes}
@@ -143,7 +143,7 @@ export function EmbeddedWorkflowView({
                         variant={BackgroundVariant.Dots}
                         gap={20}
                         size={1}
-                        color="rgba(255,255,255,0.12)"
+                        color="rgba(255,255,255,0.18)"
                     />
                     {showMiniMap && (
                         <MiniMap

--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -121,7 +121,7 @@ export function EmbeddedWorkflowView({
     };
 
     return (
-        <div className="h-screen w-screen relative bg-[#0a0a14]">
+        <div className="h-screen w-screen relative bg-[#11111c]">
             <ReactFlowProvider>
                 <ReactFlow
                     nodes={nodes}
@@ -134,13 +134,16 @@ export function EmbeddedWorkflowView({
                     panOnDrag={true}
                     zoomOnScroll={true}
                     fitView
+                    fitViewOptions={{ padding: 0.15, minZoom: 0.7, maxZoom: 1.2 }}
+                    minZoom={0.4}
+                    maxZoom={2}
                     proOptions={{ hideAttribution: true }}
                 >
                     <Background
                         variant={BackgroundVariant.Dots}
                         gap={20}
                         size={1}
-                        color="rgba(255,255,255,0.07)"
+                        color="rgba(255,255,255,0.12)"
                     />
                     {showMiniMap && (
                         <MiniMap


### PR DESCRIPTION
## Summary

The embedded canvas was unreadable when iframed into dark host pages — wide workflows auto-fit at ~30% zoom (labels below legibility), and the near-black canvas bg blended into both node fills and host page chrome.

- **Bg `#0a0a14` → `#1a1a2e`** — now matches the existing "selected" StateNode bg, giving a clear luminance step above the node fill (`#12121f`) so nodes have shape and the canvas has its own visual layer instead of disappearing into the host page.
- **`fitViewOptions={{ padding: 0.15, minZoom: 0.7, maxZoom: 1.2 }}` + global `minZoom: 0.4`** — wide workflows pan rather than shrink past readable. Manual zoom-out also capped to keep labels legible.
- **Dot grid `0.07 → 0.18`** — gives the canvas texture and depth at zoom-out without competing with edges/labels.

## Test plan

- [ ] `/embed/<shareId>` reads as its own visual layer when iframed into a dark host page (e.g. the `symflow-laravel-*` showcases) instead of bleeding into host chrome
- [ ] Wide workflows (10+ nodes, e.g. expense approval) are readable on first paint without manual zoom
- [ ] Manual scroll-zoom still works, capped at `[0.4, 2]`
- [ ] `/w/<shareId>` and the editor are unchanged (only the embed view was touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)