### PR TITLE
fix(blog): swap share IDs in laravel showcases post

### DIFF
--- a/lib/data/blog-posts.ts
+++ b/lib/data/blog-posts.ts
@@ -30,7 +30,7 @@ This post is a tour of what each one demonstrates, what they share, and where to
 | AND-join | \`finalize\` consumes a token from each \`*_approved\` place | \`merge\` consumes \`code_approved\` AND \`qa_approved\` |
 | Roles | employee, legal, finance, manager | developer, reviewer, qa |
 | UI | Livewire 3 + Tailwind, kanban dashboard, Mermaid diagram | Same stack, same diagram component |
-| Share canvas | [\`/w/9e50940e6f0e0d02\`](https://symflowbuilder.com/w/9e50940e6f0e0d02) | [\`/w/86b557637fa5a7aa\`](https://symflowbuilder.com/w/86b557637fa5a7aa) |
+| Share canvas | [\`/w/86b557637fa5a7aa\`](https://symflowbuilder.com/w/86b557637fa5a7aa) | [\`/w/9e50940e6f0e0d02\`](https://symflowbuilder.com/w/9e50940e6f0e0d02) |
 
 They are deliberately built on the same scaffolding so you can diff them and see what is engine concern vs. domain concern.
 
@@ -128,7 +128,7 @@ That sequence is identical to what you would get from Symfony's stock workflow c
 
 Both repos ship a \`workflow.yaml\` file that is the same workflow expressed in SymFlowBuilder's import format. So you can:
 
-1. Open the public canvas — [expense approval](https://symflowbuilder.com/w/9e50940e6f0e0d02) or [issue tracker](https://symflowbuilder.com/w/86b557637fa5a7aa)
+1. Open the public canvas — [expense approval](https://symflowbuilder.com/w/86b557637fa5a7aa) or [issue tracker](https://symflowbuilder.com/w/9e50940e6f0e0d02)
 2. Drag a place around, add a transition, change a guard
 3. Hit Export → **PHP (Laravel)**
 4. Paste the output into the repo's \`config/laraflow.php\`


### PR DESCRIPTION
## Summary

The blog post [Two Runnable symflow-laravel Showcases](/blog/symflow-laravel-showcases-expense-approval-and-issue-tracker) lifted the share IDs straight from the two showcase READMEs, which had them copy-pasted from each other. Production reality:

- `86b557637fa5a7aa` → expense-approval workflow
- `9e50940e6f0e0d02` → issue-tracker workflow

Sibling fixes in [symflow-laravel-expense-approval#1](https://github.com/vandetho/symflow-laravel-expense-approval/pull/1) and [symflow-laravel-issue-tracker#1](https://github.com/vandetho/symflow-laravel-issue-tracker/pull/1) correct the embed `src` and "Open full size" links in those repos. This PR is the matching correction in the blog comparison table and round-trip section.

## Test plan

- [ ] `/blog/symflow-laravel-showcases-expense-approval-and-issue-tracker` — comparison table row "Share canvas" links the expense column to `86b...` and the issue-tracker column to `9e5...`
- [ ] Round-trip section's "expense approval" link opens the expense workflow on the canvas; "issue tracker" link opens the issue-tracker workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)