### PR TITLE
fix(embed): hide FeedbackFab on /embed/ routes

### DIFF
--- a/components/feedback-fab.tsx
+++ b/components/feedback-fab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import { usePathname } from "next/navigation";
 import {
     MessageCircle,
     X,
@@ -47,6 +48,7 @@ const MAX_IMAGES = 3;
 const MAX_IMAGE_SIZE = 2 * 1024 * 1024; // 2MB
 
 export function FeedbackFab() {
+    const pathname = usePathname();
     const [open, setOpen] = useState(false);
     // Right side is occupied by the simulator sheet during play —
     // dock the FAB on the left then to avoid overlap.
@@ -130,6 +132,8 @@ export function FeedbackFab() {
             setSending(false);
         }
     }, [type, message, name, email, subject, images]);
+
+    if (pathname?.startsWith("/embed/")) return null;
 
     return (
         <>


### PR DESCRIPTION
## Summary

The feedback FAB is mounted in `app/layout.tsx` so it renders on every route — including `/embed/<shareId>`. Inside an iframe in a host app (e.g. the symflow-laravel showcases) it reads as the *host's* chat widget, not ours, which is misleading.

It still belongs on `/w/<shareId>` (the first-party share view) and everywhere else, so this is a narrow scope fix: bail out of the component when `pathname` starts with `/embed/`.

## Changes

- `components/feedback-fab.tsx` — early-return `null` on `/embed/*` paths via `usePathname()`

## Test plan

- [ ] FAB visible on `/`, `/editor`, `/blog`, `/dashboard`, `/w/<shareId>` (unchanged)
- [ ] FAB does not render on `/embed/<shareId>` (and any sub-routes if added later)
- [ ] No layout shift on the embed canvas where the FAB used to overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)