### PR TITLE
feat(embed): scenario toggle, scroll-zoom off, marking blog + features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,5 +116,6 @@ If a component doesn't exist, build it in `/components/ui/` using Radix primitiv
 - Iframe embed: `/embed/[shareId]` — minimal chrome, fit-to-view canvas, branding watermark
 - Both routes resolve via `Workflow.shareId` (unique) and require `isPublic = true`
 - `/embed/*` ships with `Content-Security-Policy: frame-ancestors *` (set in `next.config.ts`) — do not block-list it; it is the only path explicitly meant to be framed
-- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark, `?marking=place_a,place_b` highlights the listed places (read by `EmbeddedWorkflowView` → `useExternalMarkingStore` → `StateNode`); host apps rebuild the iframe `src` to push live state from their own marking store
+- Embed query params: `?minimap=0` hides the minimap, `?branding=0` hides the SymFlowBuilder watermark, `?scenario=0` hides the Run-scenario button + simulator panel, `?marking=place_a,place_b` highlights the listed places (read by `EmbeddedWorkflowView` → `useExternalMarkingStore` → `StateNode`); host apps rebuild the iframe `src` to push live state from their own marking store
+- Embed canvas disables scroll/pinch/double-click zoom (so scrolling the host page doesn't accidentally zoom the iframe); pan is still allowed and `fitView` is floored at `minZoom: 0.7` to keep labels readable
 - Mermaid copy buttons (dashboard + shared view) wrap output in a fenced ` ```mermaid ` block so paste-into-README "just works"

--- a/app/embed/[shareId]/EmbeddedWorkflowView.tsx
+++ b/app/embed/[shareId]/EmbeddedWorkflowView.tsx
@@ -45,6 +45,7 @@ interface Props {
     simulationConfig?: Record<string, unknown> | null;
     showMiniMap: boolean;
     showBranding: boolean;
+    showScenario: boolean;
     autoPlay: boolean;
     externalMarking: string[];
 }
@@ -58,6 +59,7 @@ export function EmbeddedWorkflowView({
     simulationConfig,
     showMiniMap,
     showBranding,
+    showScenario,
     autoPlay,
     externalMarking,
 }: Props) {
@@ -132,7 +134,9 @@ export function EmbeddedWorkflowView({
                     nodesConnectable={false}
                     elementsSelectable={false}
                     panOnDrag={true}
-                    zoomOnScroll={true}
+                    zoomOnScroll={false}
+                    zoomOnPinch={false}
+                    zoomOnDoubleClick={false}
                     fitView
                     fitViewOptions={{ padding: 0.15, minZoom: 0.7, maxZoom: 1.2 }}
                     minZoom={0.4}
@@ -155,27 +159,29 @@ export function EmbeddedWorkflowView({
                 </ReactFlow>
             </ReactFlowProvider>
 
-            <div className="absolute top-3 left-3 z-30">
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className={`gap-1.5 backdrop-blur-xl border ${
-                        simActive
-                            ? "text-[var(--success)] bg-[var(--success-dim)] border-[var(--success)]"
-                            : "bg-[var(--glass-base)] border-[var(--glass-border)]"
-                    }`}
-                    onClick={handleToggle}
-                >
-                    {simActive ? (
-                        <Square className="w-3.5 h-3.5" />
-                    ) : (
-                        <Play className="w-3.5 h-3.5" />
-                    )}
-                    {simActive ? "Stop" : "Run scenario"}
-                </Button>
-            </div>
+            {showScenario && (
+                <div className="absolute top-3 left-3 z-30">
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className={`gap-1.5 backdrop-blur-xl border ${
+                            simActive
+                                ? "text-[var(--success)] bg-[var(--success-dim)] border-[var(--success)]"
+                                : "bg-[var(--glass-base)] border-[var(--glass-border)]"
+                        }`}
+                        onClick={handleToggle}
+                    >
+                        {simActive ? (
+                            <Square className="w-3.5 h-3.5" />
+                        ) : (
+                            <Play className="w-3.5 h-3.5" />
+                        )}
+                        {simActive ? "Stop" : "Run scenario"}
+                    </Button>
+                </div>
+            )}
 
-            <SimulatorPanel />
+            {showScenario && <SimulatorPanel />}
 
             {showBranding && (
                 <a

--- a/app/embed/[shareId]/page.tsx
+++ b/app/embed/[shareId]/page.tsx
@@ -52,6 +52,7 @@ export default async function EmbedWorkflowPage({
 
     const showMiniMap = query.minimap !== "0";
     const showBranding = query.branding !== "0";
+    const showScenario = query.scenario !== "0";
     const autoPlay = query.play === "1";
     const externalMarking = parseMarkingParam(query.marking);
 
@@ -67,6 +68,7 @@ export default async function EmbedWorkflowPage({
             }
             showMiniMap={showMiniMap}
             showBranding={showBranding}
+            showScenario={showScenario}
             autoPlay={autoPlay}
             externalMarking={externalMarking}
         />

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -16,6 +16,7 @@ import {
     CircleDot,
     Gem,
     Weight,
+    Radio,
     type LucideIcon,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -155,6 +156,12 @@ const CATEGORIES: { title: string; features: Feature[] }[] = [
                 title: "Cloud Save",
                 description:
                     "Authenticated users get auto-save with debounced sync to the cloud. Guest drafts persist to localStorage and migrate automatically on sign-in.",
+            },
+            {
+                icon: Radio,
+                title: "Embed with Live Marking",
+                description:
+                    "Drop the canvas into your own app via /embed/<shareId>. Pass ?marking=place_a,place_b and the embedded canvas lights up the active places in real time — perfect for showing runtime state next to a Symfony or Laravel app's domain UI. Toggle minimap, branding, and scenario runner with query params.",
             },
         ],
     },

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Star } from "lucide-react";
 import { LogoWithText } from "@/components/ui/logo";
 import { Button } from "@/components/ui/button";
 import { GitHubIcon } from "@/components/ui/icons";
@@ -20,7 +21,29 @@ interface NavbarProps {
     sticky?: boolean;
 }
 
-export function Navbar({ activePath, session, sticky = true }: NavbarProps) {
+async function fetchGithubStars(): Promise<number | null> {
+    try {
+        const res = await fetch("https://api.github.com/repos/vandetho/symflowbuilder", {
+            headers: { Accept: "application/vnd.github+json" },
+            next: { revalidate: 3600 },
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as { stargazers_count?: number };
+        return typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+    } catch {
+        return null;
+    }
+}
+
+function formatStars(n: number): string {
+    if (n < 1000) return String(n);
+    if (n < 10000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+    return `${Math.round(n / 1000)}k`;
+}
+
+export async function Navbar({ activePath, session, sticky = true }: NavbarProps) {
+    const stars = await fetchGithubStars();
+
     return (
         <nav
             className={`${sticky ? "sticky top-0" : ""} z-50 border-b border-(--glass-border) bg-[#0a0a14]/95 backdrop-blur-xl`}
@@ -51,10 +74,21 @@ export function Navbar({ activePath, session, sticky = true }: NavbarProps) {
                         href="https://github.com/vandetho/symflowbuilder"
                         target="_blank"
                         rel="noopener noreferrer"
+                        title={
+                            stars !== null
+                                ? `${stars.toLocaleString()} stars on GitHub`
+                                : "GitHub"
+                        }
                     >
                         <Button variant="ghost" size="sm" className="gap-1.5">
                             <GitHubIcon className="w-3.5 h-3.5" />
                             <span className="hidden sm:inline">GitHub</span>
+                            {stars !== null && (
+                                <span className="hidden sm:inline-flex items-center gap-0.5 pl-1.5 ml-0.5 border-l border-(--glass-border) text-[10px] font-mono text-(--text-secondary)">
+                                    <Star className="w-3 h-3 fill-(--warning) text-(--warning)" />
+                                    {formatStars(stars)}
+                                </span>
+                            )}
                         </Button>
                     </a>
                     <div className="hidden sm:flex items-center gap-2">

--- a/lib/data/blog-posts.ts
+++ b/lib/data/blog-posts.ts
@@ -9,6 +9,108 @@ export interface BlogPost {
 
 export const blogPosts: BlogPost[] = [
     {
+        slug: "embed-live-workflow-state-with-marking-query-param",
+        title: "Embed Your Workflow's Live State with One Query Param",
+        date: "2026-05-01",
+        excerpt:
+            "The /embed iframe now accepts ?marking=place_a,place_b and lights up the active places in real time. Drop the canvas into your Symfony or Laravel app, push your domain object's marking on every render, and the embed mirrors live state — no JS, no postMessage, no polling.",
+        tags: ["feature", "embed", "marking", "laravel"],
+        content: `## What changed
+
+\`/embed/<shareId>\` accepts a new \`?marking=\` query param. Every place name listed in it lights up on the embedded canvas with the same green pulse the simulator uses. Anything not in the list dims out.
+
+\`\`\`
+https://symflowbuilder.com/embed/abc123?marking=legal_review,manager_review
+\`\`\`
+
+That is the whole feature. No JS to load, no postMessage handshake, no polling. The host app just rebuilds the iframe \`src\` whenever its model's marking changes and the embed re-renders with the new active places highlighted.
+
+## Why it exists
+
+We shipped iframe embeds a few months ago so you could drop a workflow canvas next to your docs or a project page. That worked for static "this is the design" use cases. But as soon as people started running real Symfony or Laravel apps and wanting the canvas to *track the runtime state of an entity* — *"this expense report is currently in legal_review and finance_review"* — the embed had nothing to say. You had to render a separate Mermaid diagram or a custom kanban to show that.
+
+Now the same canvas you designed your workflow on can also be the live status display, with one extra query string parameter.
+
+## How a Laravel host wires it up
+
+In a Livewire component, push your domain object's marking into the iframe \`src\` like this:
+
+\`\`\`blade
+@php $embedMarking = implode(',', array_map('urlencode', array_keys($expense->marking))); @endphp
+<iframe wire:key="symflowbuilder-iframe-{{ $embedMarking }}"
+        src="https://symflowbuilder.com/embed/{{ config('symflow.share_id') }}?branding=0&minimap=0{{ $embedMarking !== '' ? '&marking='.$embedMarking : '' }}"
+        width="100%" height="500"
+        class="rounded-lg"
+        loading="lazy"
+        title="Workflow"></iframe>
+\`\`\`
+
+Two bits worth pointing out:
+
+- The \`wire:key\` includes the marking. That is what tells Livewire to re-mount the iframe (and force a reload) every time the marking changes. Without it, Livewire keeps the same iframe DOM and the \`src\` change does not always trigger a navigation.
+- We \`urlencode\` each place name. Place names in well-formed Symfony workflows match \`/^[a-z][a-z0-9_]*$/\` so this is mostly belt-and-braces, but if you ever rename a place to something exotic you will be glad it is there.
+
+A Symfony Twig template looks almost identical:
+
+\`\`\`twig
+{% set embedMarking = expense.marking|map(p => p|url_encode)|join(',') %}
+<iframe src="https://symflowbuilder.com/embed/{{ shareId }}?branding=0&minimap=0{{ embedMarking ? '&marking=' ~ embedMarking : '' }}"
+        width="100%" height="500"></iframe>
+\`\`\`
+
+## What it looks like for the user
+
+When the marking changes — \`submit\` fires, a token moves from \`draft\` into three parallel review places — the iframe reloads with the new \`?marking=\` and the canvas re-fits with three places pulsing green and the rest dimmed. Reviewers looking at the page can see *"these are the people we are waiting on"* without you having to render a second diagram.
+
+Particularly nice for Petri-net workflows where multiple places are marked simultaneously: the AND-split / AND-join pattern is hard to convey with a single-current-state widget, but trivial when the canvas itself is the status display.
+
+## Why a query param and not postMessage
+
+We considered \`postMessage\`. It is smoother — the iframe stays mounted and the parent posts \`{type: 'symflow:marking', places: [...]}\` whenever the marking changes, with no reload flicker. We may add it later as an opt-in upgrade.
+
+But for v1, the query-param transport is the cheapest possible thing for both sides:
+
+- **No JS in the host.** A Livewire/Twig template that already renders an entity's state can build the URL with one line of templating. No \`<script>\` tags, no event listeners.
+- **Works with caching layers.** Each marking value produces a unique URL, so CDN/browser cache behaves correctly.
+- **SSR-friendly.** The marking is parsed server-side in \`/embed/<shareId>\`'s page component, validated, and passed straight to the React component as a prop. The first paint already has the right places highlighted.
+
+The cost is a small reload flicker on each transition. For a status display that updates a few times a day per entity, that is invisible.
+
+## Other embed knobs
+
+While we were in the area, two other small things moved:
+
+- **\`?scenario=0\`** hides the Run-scenario button and the simulator panel. Useful when the embed is purely a status display and you do not want users opening the playable scenario.
+- **Scroll, pinch, and double-click zoom are off** in the embed by default. Scrolling past the iframe in the host page used to land in the canvas and accidentally zoom; now scroll passes through to the host. Pan-on-drag still works, and the "Open full size" affordance gives users the full interactive view if they want it.
+
+The full embed surface today:
+
+| Param | Default | Effect |
+|---|---|---|
+| \`marking\` | empty | Highlights the listed places (comma-separated) |
+| \`minimap\` | shown | \`?minimap=0\` hides the minimap |
+| \`branding\` | shown | \`?branding=0\` hides the SymFlowBuilder watermark |
+| \`scenario\` | shown | \`?scenario=0\` hides the Run-scenario button |
+| \`play\` | off | \`?play=1\` autostarts the scenario on load |
+
+## Where to see it live
+
+The two [\`symflow-laravel\`](https://github.com/vandetho/symflow-laravel) showcases use this end-to-end:
+
+- [\`symflow-laravel-expense-approval\`](https://github.com/vandetho/symflow-laravel-expense-approval) — when an expense is sitting in legal + finance + manager review, all three places pulse on the embedded canvas
+- [\`symflow-laravel-issue-tracker\`](https://github.com/vandetho/symflow-laravel-issue-tracker) — \`code_review\` and \`qa_review\` both light up while the issue is in parallel review
+
+Both repos are runnable in two minutes (\`composer install && php artisan migrate:fresh --seed && php artisan serve\`) so you can watch the marking update live as you fire transitions.
+
+## Try it on your own workflow
+
+1. [Save a workflow](/dashboard) and click **Share** to get a share ID
+2. In whatever framework you are using, build the iframe \`src\` with your entity's current marking
+3. Refresh on transitions
+
+That is the entire integration. If you build something with it, [send us a link](https://github.com/vandetho/symflowbuilder/discussions) — we would love to feature it.`,
+    },
+    {
         slug: "symflow-laravel-showcases-expense-approval-and-issue-tracker",
         title: "Two Runnable symflow-laravel Showcases: Expense Approval and Issue Tracker",
         date: "2026-05-01",


### PR DESCRIPTION
## Summary

Round out the `?marking=` rollout that started with [#102](https://github.com/vandetho/symflowbuilder/pull/102) and the bg/zoom fix in [#104](https://github.com/vandetho/symflowbuilder/pull/104):

- **`?scenario=0` query param** hides the Run-scenario button + simulator panel for hosts that just want a passive status display
- **Embed canvas scroll/pinch/double-click zoom disabled** so scrolling past the iframe in a host page passes through instead of hijacking the wheel; pan-on-drag and the "Open full size" link still cover the interactive case
- **Star count badge** on the navbar GitHub button (1h cached fetch from the public GitHub API, falls back gracefully on rate-limit/error)
- **Features page**: new "Embed with Live Marking" entry under Save & Share
- **Blog post** explaining the integration end-to-end with Laravel/Livewire and Symfony/Twig examples
- **`CLAUDE.md`** updated for the new query params and zoom defaults

## Embed query params after this PR

| Param | Default | Effect |
|---|---|---|
| `marking` | empty | Highlights the listed places |
| `minimap` | shown | `?minimap=0` hides minimap |
| `branding` | shown | `?branding=0` hides watermark |
| `scenario` | shown | `?scenario=0` hides Run-scenario + sim panel |
| `play` | off | `?play=1` autostarts the scenario |

## Test plan

- [ ] `/embed/<shareId>` no longer hijacks the wheel; scroll the host page works through the iframe
- [ ] `/embed/<shareId>?scenario=0` hides the Run-scenario button and the simulator panel
- [ ] `/embed/<shareId>` (default) still shows scenario button + simulator
- [ ] Star count visible on `/`, `/features`, etc. on a viewport ≥sm; falls back silently if GitHub API fails
- [ ] `/features` shows the new "Embed with Live Marking" card under Save & Share
- [ ] `/blog/embed-live-workflow-state-with-marking-query-param` renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)