### PR TITLE
feat(landing): add Embed with Live Marking to feature grid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import {
     Package,
     Gem,
     Weight,
+    Radio,
 } from "lucide-react";
 import { GitHubIcon } from "@/components/ui/icons";
 import { Logo } from "@/components/ui/logo";
@@ -89,6 +90,12 @@ const FEATURES = [
         title: "Shareable Links",
         description:
             "Generate read-only public links to share your workflow designs with teammates. No account required to view.",
+    },
+    {
+        icon: Radio,
+        title: "Embed with Live Marking",
+        description:
+            "Drop the canvas into your own app via /embed/<shareId>. Pass ?marking=place_a,place_b and active places light up in real time — perfect for showing runtime state next to your domain UI.",
     },
     {
         icon: Package,


### PR DESCRIPTION
## Summary

Round out the embed-marking rollout by surfacing it on the home page's feature grid. The entry under "Save & Share" on `/features` already exists from PR #110 — this matches it on `/`.

## Changes

- `app/page.tsx` — new feature card with `Radio` icon, slotted between **Shareable Links** and **Node.js Engine**

## Test plan

- [ ] `/` renders the new card in the feature grid alongside the existing 13 cards
- [ ] Card uses the consistent icon-tile + title + description layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)