### PR TITLE
feat(editor): replace one-click share with full share dialog

### DIFF
--- a/components/dashboard/share-workflow-button.tsx
+++ b/components/dashboard/share-workflow-button.tsx
@@ -1,18 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { Share2, Link2, Link2Off, Copy, Check, Code2 } from "lucide-react";
-import { toast } from "sonner";
+import { Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    DialogDescription,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+import { ShareDialog } from "@/components/share/share-dialog";
 
 export function ShareWorkflowButton({
     workflowId,
@@ -23,66 +14,6 @@ export function ShareWorkflowButton({
 }) {
     const [open, setOpen] = useState(false);
     const [currentShareId, setCurrentShareId] = useState(shareId);
-    const [loading, setLoading] = useState(false);
-    const [copied, setCopied] = useState(false);
-    const [embedCopied, setEmbedCopied] = useState(false);
-    const router = useRouter();
-
-    const origin = typeof window !== "undefined" ? window.location.origin : "";
-    const shareUrl = currentShareId ? `${origin}/w/${currentShareId}` : "";
-    const embedUrl = currentShareId ? `${origin}/embed/${currentShareId}` : "";
-    const embedSnippet = currentShareId
-        ? `<iframe src="${embedUrl}" width="100%" height="500" style="border:0;border-radius:14px" loading="lazy" title="SymFlowBuilder workflow"></iframe>`
-        : "";
-
-    const handleShare = async () => {
-        setLoading(true);
-        try {
-            const res = await fetch(`/api/workflows/${workflowId}/share`, {
-                method: "POST",
-            });
-            if (!res.ok) throw new Error("Failed");
-            const data = await res.json();
-            setCurrentShareId(data.shareId);
-            toast.success("Workflow is now public");
-            router.refresh();
-        } catch {
-            toast.error("Failed to share");
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const handleUnshare = async () => {
-        setLoading(true);
-        try {
-            const res = await fetch(`/api/workflows/${workflowId}/share`, {
-                method: "DELETE",
-            });
-            if (!res.ok) throw new Error("Failed");
-            setCurrentShareId(null);
-            toast.success("Workflow is now private");
-            router.refresh();
-        } catch {
-            toast.error("Failed to unshare");
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const handleCopy = () => {
-        navigator.clipboard.writeText(shareUrl);
-        setCopied(true);
-        toast.success("Link copied");
-        setTimeout(() => setCopied(false), 2000);
-    };
-
-    const handleCopyEmbed = () => {
-        navigator.clipboard.writeText(embedSnippet);
-        setEmbedCopied(true);
-        toast.success("Embed snippet copied");
-        setTimeout(() => setEmbedCopied(false), 2000);
-    };
 
     return (
         <>
@@ -95,101 +26,13 @@ export function ShareWorkflowButton({
                 <Share2 className="w-3 h-3" />
             </Button>
 
-            <Dialog open={open} onOpenChange={setOpen}>
-                <DialogContent className="max-w-sm">
-                    <DialogHeader>
-                        <DialogTitle>Share Workflow</DialogTitle>
-                        <DialogDescription>
-                            {currentShareId
-                                ? "This workflow is publicly accessible via the link below."
-                                : "Make this workflow public so anyone with the link can view it."}
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="flex flex-col gap-4 mt-3">
-                        {currentShareId ? (
-                            <>
-                                <div className="flex items-center gap-2">
-                                    <Input
-                                        value={shareUrl}
-                                        readOnly
-                                        className="text-xs flex-1"
-                                    />
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        onClick={handleCopy}
-                                        className="shrink-0"
-                                    >
-                                        {copied ? (
-                                            <Check className="w-3.5 h-3.5 text-[var(--success)]" />
-                                        ) : (
-                                            <Copy className="w-3.5 h-3.5" />
-                                        )}
-                                    </Button>
-                                </div>
-                                <div className="flex flex-col gap-2">
-                                    <div className="flex items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
-                                        <Code2 className="w-3 h-3" />
-                                        Embed
-                                    </div>
-                                    <div className="flex items-center gap-2">
-                                        <Input
-                                            value={embedSnippet}
-                                            readOnly
-                                            className="text-[10px] font-mono flex-1"
-                                        />
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={handleCopyEmbed}
-                                            className="shrink-0"
-                                        >
-                                            {embedCopied ? (
-                                                <Check className="w-3.5 h-3.5 text-[var(--success)]" />
-                                            ) : (
-                                                <Copy className="w-3.5 h-3.5" />
-                                            )}
-                                        </Button>
-                                    </div>
-                                    <p className="text-[10px] text-[var(--text-muted)]">
-                                        Drop into MDX, HTML, or any docs site that allows
-                                        iframes.
-                                    </p>
-                                </div>
-                                <div className="flex justify-between">
-                                    <div className="flex items-center gap-1.5 text-[10px] text-[var(--success)]">
-                                        <Link2 className="w-3 h-3" />
-                                        Public
-                                    </div>
-                                    <Button
-                                        variant="danger"
-                                        size="sm"
-                                        onClick={handleUnshare}
-                                        disabled={loading}
-                                        className="gap-1.5"
-                                    >
-                                        <Link2Off className="w-3 h-3" />
-                                        {loading ? "Removing..." : "Make Private"}
-                                    </Button>
-                                </div>
-                            </>
-                        ) : (
-                            <div className="flex justify-end">
-                                <Button
-                                    size="sm"
-                                    onClick={handleShare}
-                                    disabled={loading}
-                                    className="gap-1.5"
-                                >
-                                    <Share2 className="w-3.5 h-3.5" />
-                                    {loading ? "Sharing..." : "Make Public"}
-                                </Button>
-                            </div>
-                        )}
-                    </div>
-                </DialogContent>
-            </Dialog>
+            <ShareDialog
+                workflowId={workflowId}
+                shareId={currentShareId}
+                open={open}
+                onOpenChange={setOpen}
+                onShareIdChange={setCurrentShareId}
+            />
         </>
     );
 }

--- a/components/editor/panels/EditorToolbar.tsx
+++ b/components/editor/panels/EditorToolbar.tsx
@@ -11,7 +11,6 @@ import {
     LogIn,
     Save,
     Share2,
-    Check,
     Play,
     Square,
     Globe,
@@ -44,6 +43,7 @@ import {
 } from "@/components/ui/dialog";
 import { useEditorStore } from "@/stores/editor";
 import { useSimulatorStore } from "@/stores/simulator";
+import { ShareDialog } from "@/components/share/share-dialog";
 import { GitHubIcon } from "@/components/ui/icons";
 import { Badge } from "@/components/ui/badge";
 import { version } from "@/package.json";
@@ -184,51 +184,54 @@ function ShareButton() {
     const { data: session } = useSession();
     const params = useParams();
     const workflowId = params?.id as string | undefined;
-    const [copied, setCopied] = useState(false);
+    const [open, setOpen] = useState(false);
+    const [shareId, setShareId] = useState<string | null>(null);
+    const [hasFetched, setHasFetched] = useState(false);
 
     if (!session?.user || !workflowId) return null;
 
-    const handleShare = async () => {
+    const handleOpen = async () => {
+        setOpen(true);
+        if (hasFetched) return;
         try {
-            const res = await fetch(`/api/workflows/${workflowId}/share`, {
-                method: "POST",
-            });
-            if (!res.ok) throw new Error("Failed");
-            const data = await res.json();
-            const url = `${window.location.origin}/w/${data.shareId}`;
-            await navigator.clipboard.writeText(url);
-            toast.success(
-                "Share link copied — anyone with this link can view your workflow"
-            );
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            const res = await fetch(`/api/workflows/${workflowId}`);
+            if (res.ok) {
+                const data = await res.json();
+                setShareId(data.shareId ?? null);
+            }
         } catch {
-            toast.error("Failed to generate share link");
+            // Dialog still works — user can hit "Make Public" to generate a fresh link.
+        } finally {
+            setHasFetched(true);
         }
     };
 
     return (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5"
-                    onClick={handleShare}
-                    disabled={copied}
-                >
-                    {copied ? (
-                        <Check className="w-3.5 h-3.5 text-[var(--success)]" />
-                    ) : (
+        <>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={handleOpen}
+                    >
                         <Share2 className="w-3.5 h-3.5" />
-                    )}
-                    {copied ? "Copied!" : "Share"}
-                </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-                Generate a public read-only link
-            </TooltipContent>
-        </Tooltip>
+                        Share
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                    Public link, embed code, or revoke access
+                </TooltipContent>
+            </Tooltip>
+            <ShareDialog
+                workflowId={workflowId}
+                shareId={shareId}
+                open={open}
+                onOpenChange={setOpen}
+                onShareIdChange={setShareId}
+            />
+        </>
     );
 }
 

--- a/components/share/share-dialog.tsx
+++ b/components/share/share-dialog.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Share2, Link2, Link2Off, Copy, Check, Code2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface ShareDialogProps {
+    workflowId: string;
+    shareId: string | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onShareIdChange?: (shareId: string | null) => void;
+}
+
+export function ShareDialog({
+    workflowId,
+    shareId,
+    open,
+    onOpenChange,
+    onShareIdChange,
+}: ShareDialogProps) {
+    const [currentShareId, setCurrentShareId] = useState(shareId);
+    const [loading, setLoading] = useState(false);
+    const [copied, setCopied] = useState(false);
+    const [embedCopied, setEmbedCopied] = useState(false);
+    const router = useRouter();
+
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const shareUrl = currentShareId ? `${origin}/w/${currentShareId}` : "";
+    const embedUrl = currentShareId ? `${origin}/embed/${currentShareId}` : "";
+    const embedSnippet = currentShareId
+        ? `<iframe src="${embedUrl}" width="100%" height="500" style="border:0;border-radius:14px" loading="lazy" title="SymFlowBuilder workflow"></iframe>`
+        : "";
+
+    const updateShareId = (next: string | null) => {
+        setCurrentShareId(next);
+        onShareIdChange?.(next);
+    };
+
+    const handleShare = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/workflows/${workflowId}/share`, {
+                method: "POST",
+            });
+            if (!res.ok) throw new Error("Failed");
+            const data = await res.json();
+            updateShareId(data.shareId);
+            toast.success("Workflow is now public");
+            router.refresh();
+        } catch {
+            toast.error("Failed to share");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleUnshare = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/workflows/${workflowId}/share`, {
+                method: "DELETE",
+            });
+            if (!res.ok) throw new Error("Failed");
+            updateShareId(null);
+            toast.success("Workflow is now private");
+            router.refresh();
+        } catch {
+            toast.error("Failed to unshare");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(shareUrl);
+        setCopied(true);
+        toast.success("Link copied");
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const handleCopyEmbed = () => {
+        navigator.clipboard.writeText(embedSnippet);
+        setEmbedCopied(true);
+        toast.success("Embed snippet copied");
+        setTimeout(() => setEmbedCopied(false), 2000);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Share Workflow</DialogTitle>
+                    <DialogDescription>
+                        {currentShareId
+                            ? "This workflow is publicly accessible via the link below."
+                            : "Make this workflow public so anyone with the link can view it."}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-col gap-4 mt-3">
+                    {currentShareId ? (
+                        <>
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    value={shareUrl}
+                                    readOnly
+                                    className="text-xs flex-1"
+                                />
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={handleCopy}
+                                    className="shrink-0"
+                                >
+                                    {copied ? (
+                                        <Check className="w-3.5 h-3.5 text-[var(--success)]" />
+                                    ) : (
+                                        <Copy className="w-3.5 h-3.5" />
+                                    )}
+                                </Button>
+                            </div>
+                            <div className="flex flex-col gap-2">
+                                <div className="flex items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
+                                    <Code2 className="w-3 h-3" />
+                                    Embed
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        value={embedSnippet}
+                                        readOnly
+                                        className="text-[10px] font-mono flex-1"
+                                    />
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={handleCopyEmbed}
+                                        className="shrink-0"
+                                    >
+                                        {embedCopied ? (
+                                            <Check className="w-3.5 h-3.5 text-[var(--success)]" />
+                                        ) : (
+                                            <Copy className="w-3.5 h-3.5" />
+                                        )}
+                                    </Button>
+                                </div>
+                                <p className="text-[10px] text-[var(--text-muted)]">
+                                    Drop into MDX, HTML, or any docs site that allows
+                                    iframes.
+                                </p>
+                            </div>
+                            <div className="flex justify-between">
+                                <div className="flex items-center gap-1.5 text-[10px] text-[var(--success)]">
+                                    <Link2 className="w-3 h-3" />
+                                    Public
+                                </div>
+                                <Button
+                                    variant="danger"
+                                    size="sm"
+                                    onClick={handleUnshare}
+                                    disabled={loading}
+                                    className="gap-1.5"
+                                >
+                                    <Link2Off className="w-3 h-3" />
+                                    {loading ? "Removing..." : "Make Private"}
+                                </Button>
+                            </div>
+                        </>
+                    ) : (
+                        <div className="flex justify-end">
+                            <Button
+                                size="sm"
+                                onClick={handleShare}
+                                disabled={loading}
+                                className="gap-1.5"
+                            >
+                                <Share2 className="w-3.5 h-3.5" />
+                                {loading ? "Sharing..." : "Make Public"}
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
## Summary

The editor toolbar's Share button used to POST to the share endpoint, copy the URL to the clipboard, and stop there. Two problems:

1. **No embed code.** The dashboard already had a richer share dialog with the iframe snippet — the editor didn't, so users on the editor side never saw the embed feature surfaced.
2. **Re-rolled the share ID on every click.** `POST /api/workflows/<id>/share` always generates a fresh `randomBytes(8)` share ID, so opening the toolbar Share twice silently invalidated whatever embed someone had already pasted into a docs site.

## Changes

- **`components/share/share-dialog.tsx`** — extracts the dashboard's share dialog body into a reusable controlled component (`open` / `onOpenChange` / `shareId` / `onShareIdChange?` props)
- **`components/dashboard/share-workflow-button.tsx`** — thin wrapper, just an icon button + the shared dialog
- **`components/editor/panels/EditorToolbar.tsx`** — `ShareButton` now opens the same dialog. On first open it lazily fetches `GET /api/workflows/<id>` to learn the existing `shareId` (no extra cost when users never click Share)

Editor flow now mirrors the dashboard:

1. Click **Share** → dialog opens
2. If already public → shows `/w/<shareId>` link + iframe embed snippet (both copy-buttoned) + **Make Private** to revoke
3. If private → single **Make Public** action, dialog updates in place

## Test plan

- [ ] Editor toolbar **Share** opens the dialog (not a one-shot copy)
- [ ] Dialog shows existing share state for an already-shared workflow (no re-roll)
- [ ] Copy link, copy embed snippet, make public, make private all work from the editor toolbar
- [ ] Dashboard share button still works exactly as before (visual + behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)