### PR TITLE
feat: introduction blog post + landing page mobile fixes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,6 +57,7 @@ body {
     color: var(--text-primary);
     font-family: var(--font-sora), sans-serif;
     min-height: 100vh;
+    overflow-x: clip;
 }
 
 /* Custom scrollbar */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -148,7 +148,10 @@ export default async function LandingPage() {
 
                         <div className="flex flex-col sm:flex-row sm:items-center justify-center gap-3 mt-2 w-full sm:w-auto">
                             <Link href="/editor" className="w-full sm:w-auto">
-                                <Button size="lg" className="gap-2 text-sm w-full sm:w-auto">
+                                <Button
+                                    size="lg"
+                                    className="gap-2 text-sm w-full sm:w-auto"
+                                >
                                     Start Building
                                     <ArrowRight className="w-4 h-4" />
                                 </Button>
@@ -471,7 +474,10 @@ export default async function LandingPage() {
                                 </p>
                                 <div className="flex flex-col sm:flex-row sm:items-center justify-center gap-3 mt-2 w-full sm:w-auto">
                                     <Link href="/editor" className="w-full sm:w-auto">
-                                        <Button size="lg" className="gap-2 w-full sm:w-auto">
+                                        <Button
+                                            size="lg"
+                                            className="gap-2 w-full sm:w-auto"
+                                        >
                                             Start Building
                                             <ArrowRight className="w-4 h-4" />
                                         </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,7 +115,7 @@ export default async function LandingPage() {
                 {/* ─── Node: Hero (Initial) ─── */}
                 <FlowNode label="initial_marking" isInitial className="pt-20 pb-8">
                     <div
-                        className="absolute top-0 left-1/2 -translate-x-1/2 w-150 h-100 pointer-events-none"
+                        className="absolute top-0 left-1/2 -translate-x-1/2 w-[min(600px,100vw)] h-100 pointer-events-none"
                         style={{
                             background:
                                 "radial-gradient(ellipse at center, rgba(124,111,247,0.12) 0%, transparent 70%)",
@@ -146,9 +146,9 @@ export default async function LandingPage() {
                             production-ready YAML.
                         </p>
 
-                        <div className="flex items-center gap-3 mt-2">
-                            <Link href="/editor">
-                                <Button size="lg" className="gap-2 text-sm">
+                        <div className="flex flex-col sm:flex-row sm:items-center justify-center gap-3 mt-2 w-full sm:w-auto">
+                            <Link href="/editor" className="w-full sm:w-auto">
+                                <Button size="lg" className="gap-2 text-sm w-full sm:w-auto">
                                     Start Building
                                     <ArrowRight className="w-4 h-4" />
                                 </Button>
@@ -157,11 +157,12 @@ export default async function LandingPage() {
                                 href="https://github.com/vandetho/symflowbuilder"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                className="w-full sm:w-auto"
                             >
                                 <Button
                                     variant="outline"
                                     size="lg"
-                                    className="gap-2 text-sm"
+                                    className="gap-2 text-sm w-full sm:w-auto"
                                 >
                                     <GitHubIcon className="w-4 h-4" />
                                     Star on GitHub
@@ -468,9 +469,9 @@ export default async function LandingPage() {
                                     Sign in to unlock cloud save, versioning, and
                                     shareable links.
                                 </p>
-                                <div className="flex items-center gap-3 mt-2">
-                                    <Link href="/editor">
-                                        <Button size="lg" className="gap-2">
+                                <div className="flex flex-col sm:flex-row sm:items-center justify-center gap-3 mt-2 w-full sm:w-auto">
+                                    <Link href="/editor" className="w-full sm:w-auto">
+                                        <Button size="lg" className="gap-2 w-full sm:w-auto">
                                             Start Building
                                             <ArrowRight className="w-4 h-4" />
                                         </Button>
@@ -479,11 +480,12 @@ export default async function LandingPage() {
                                         href="https://github.com/vandetho/symflowbuilder"
                                         target="_blank"
                                         rel="noopener noreferrer"
+                                        className="w-full sm:w-auto"
                                     >
                                         <Button
                                             variant="outline"
                                             size="lg"
-                                            className="gap-2"
+                                            className="gap-2 w-full sm:w-auto"
                                         >
                                             <GitHubIcon className="w-4 h-4" />
                                             View Source

--- a/components/landing/HeroGraph.tsx
+++ b/components/landing/HeroGraph.tsx
@@ -177,11 +177,11 @@ export function HeroGraph() {
     const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
     if (!mounted) {
-        return <div className="w-full h-[540px] rounded-[18px] glass animate-pulse" />;
+        return <div className="w-full h-[320px] sm:h-[420px] lg:h-[540px] rounded-[18px] glass animate-pulse" />;
     }
 
     return (
-        <div className="w-full h-[540px] rounded-[18px] glass overflow-hidden shadow-[0_16px_64px_rgba(124,111,247,0.08)]">
+        <div className="w-full h-[320px] sm:h-[420px] lg:h-[540px] rounded-[18px] glass overflow-hidden shadow-[0_16px_64px_rgba(124,111,247,0.08)]">
             <ReactFlowProvider>
                 <ReactFlow
                     nodes={DEMO_NODES}

--- a/components/landing/HeroGraph.tsx
+++ b/components/landing/HeroGraph.tsx
@@ -177,7 +177,9 @@ export function HeroGraph() {
     const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
     if (!mounted) {
-        return <div className="w-full h-[320px] sm:h-[420px] lg:h-[540px] rounded-[18px] glass animate-pulse" />;
+        return (
+            <div className="w-full h-[320px] sm:h-[420px] lg:h-[540px] rounded-[18px] glass animate-pulse" />
+        );
     }
 
     return (


### PR DESCRIPTION
## Summary

- Adds a new blog post at `/blog/symflowbuilder-design-symfony-workflows-visually` — a shareable introduction to SymFlowBuilder that can also be copied to Medium and SupportDock.
- Fixes mobile responsiveness on the landing page: hero glow no longer triggers horizontal scroll, hero/final-CTA buttons stack on narrow screens, `HeroGraph` height scales by breakpoint, and `body` gets `overflow-x: clip` as a safety net (`clip`, not `hidden`, to preserve the sticky navbar).

## Changes

**Blog post** (`lib/data/blog-posts.ts`)
- New entry: `symflowbuilder-design-symfony-workflows-visually`, dated 2026-04-20, tagged `announcement`, `symfony`, `workflow`, `editor`.
- Covers the problem, the feature set, a worked order-workflow YAML example, the simulator, the standalone `symflow` engine, the stack, and a CTA.

**Landing page responsiveness**
- `app/page.tsx:118` — hero glow overlay now `w-[min(600px,100vw)]` instead of fixed `w-150` (600px).
- `app/page.tsx:149` and `app/page.tsx:471` — hero and final-section CTAs use `flex-col sm:flex-row` with full-width buttons below `sm`.
- `components/landing/HeroGraph.tsx` — canvas height scales `320 → 420 → 540px` across `sm`/`lg` breakpoints.
- `app/globals.css:60` — `overflow-x: clip` on `body`.

## Test plan

- [ ] Visit `/blog` — new post appears at the top (sorted by date).
- [ ] Open `/blog/symflowbuilder-design-symfony-workflows-visually` — renders correctly, internal links work (`/editor`, `/blog/symflow-core-workflow-engine-for-nodejs`).
- [ ] Load `/` at 320px / 375px / 414px viewport widths — no horizontal scroll.
- [ ] Hero CTAs and final-section CTAs stack vertically and fill width on mobile.
- [ ] `HeroGraph` is appropriately sized at each breakpoint and `fitView` still works.
- [ ] Sticky navbar still sticks on scroll (regression check after `overflow-x: clip`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqvmaiCTTmhqXZmE2NDTTE)_